### PR TITLE
Improve CI PR coverage and contributor workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "go"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "go"
-    directory: "/inspect"
-    schedule:
-      interval: "weekly"
-
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,19 +4,18 @@ Describe what this PR changes and why.
 
 ## Changes
 
-- 
+-
 
 ## How To Test
 
 List commands or steps used to verify the change.
 
 ```bash
-# example
-go test ./...
+task
 ```
 
 ## Checklist
 
-- [ ] I ran relevant tests locally
+- [ ] Tests are green when ran locally
 - [ ] I updated documentation/examples when needed
 - [ ] I considered backward compatibility and migration impact

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+Describe what this PR changes and why.
+
+## Changes
+
+- 
+
+## How To Test
+
+List commands or steps used to verify the change.
+
+```bash
+# example
+go test ./...
+```
+
+## Checklist
+
+- [ ] I ran relevant tests locally
+- [ ] I updated documentation/examples when needed
+- [ ] I considered backward compatibility and migration impact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -460,6 +460,22 @@ Here are solutions to common issues you might encounter when using Pal:
    - **Possible Causes**: The service isn't checking for context cancellation in its Run method.
    - **Solution**: Ensure all long-running operations in your services respect context cancellation by checking `ctx.Done()` regularly.
 
+## Development
+
+`asdf` is the recommended package manager for development tools. Tool versions are pinned in `.tool-versions`.
+
+Basic setup:
+
+```bash
+asdf plugin add golang
+asdf plugin add golangci-lint
+asdf plugin add task
+asdf install
+task
+```
+
+If `task` runs successfully, your local development setup is ready.
+
 ## Contributing
 
 Contributions are welcome.


### PR DESCRIPTION
## Summary
- run CI on both `push` and `pull_request` events so changes are validated before merge
- add a repository PR template to standardize summaries, test notes, and readiness checks
- add a `Development` section to `README.md` with `asdf`-based setup and pinned versions in `.tool-versions`
- align Dependabot configuration for weekly updates of Go modules and GitHub Actions

## Verification
- `task test`
- `task lint`