### PR TITLE
Return cycle services in dependency errors

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -20,6 +20,18 @@ func NewMockService(t *testing.T, name string) *MockServiceDef {
 	return mock
 }
 
+type cycleServiceA struct {
+	B *cycleServiceB
+}
+
+type cycleServiceB struct {
+	C *cycleServiceC
+}
+
+type cycleServiceC struct {
+	A *cycleServiceA
+}
+
 // TestContainer_New tests the New function for Container
 func TestContainer_New(t *testing.T) {
 	t.Parallel()
@@ -83,6 +95,24 @@ func TestContainer_Init(t *testing.T) {
 		err := c.Init(t.Context())
 
 		assert.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("returns cycle with service names in error", func(t *testing.T) {
+		t.Parallel()
+
+		c := pal.NewContainer(
+			&pal.Pal{},
+			pal.Provide(&cycleServiceA{}),
+			pal.Provide(&cycleServiceB{}),
+			pal.Provide(&cycleServiceC{}),
+		)
+
+		err := c.Init(t.Context())
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cycleServiceA")
+		assert.ErrorContains(t, err, "cycleServiceB")
+		assert.ErrorContains(t, err, "cycleServiceC")
 	})
 }
 

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -3,9 +3,11 @@ package dag
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"iter"
 	"maps"
 	"slices"
+	"strings"
 )
 
 var (
@@ -13,6 +15,27 @@ var (
 	ErrCycleDetected     = errors.New("cycle detected")
 	ErrVertexNotFound    = errors.New("vertex not found")
 )
+
+type CycleError[ID cmp.Ordered] struct {
+	Cycle []ID
+}
+
+func (e *CycleError[ID]) Error() string {
+	if len(e.Cycle) == 0 {
+		return ErrCycleDetected.Error()
+	}
+
+	parts := make([]string, len(e.Cycle))
+	for i, vertex := range e.Cycle {
+		parts[i] = fmt.Sprint(vertex)
+	}
+
+	return fmt.Sprintf("%s: %s", ErrCycleDetected, strings.Join(parts, " -> "))
+}
+
+func (e *CycleError[ID]) Unwrap() error {
+	return ErrCycleDetected
+}
 
 type DAG[ID cmp.Ordered, T any] struct {
 	vertices map[ID]T
@@ -112,11 +135,11 @@ func (d *DAG[ID, T]) AddEdge(source, target ID) error {
 	d.inDegree[target]++
 
 	// Check for cycles using DFS
-	if d.hasCycle() {
+	if cycle, hasCycle := d.hasCycle(); hasCycle {
 		// Remove the edge if it creates a cycle
-		d.edges[source][target] = false
+		delete(d.edges[source], target)
 		d.inDegree[target]--
-		return ErrCycleDetected
+		return &CycleError[ID]{Cycle: cycle}
 	}
 
 	return nil
@@ -180,39 +203,60 @@ func (d *DAG[ID, T]) ReverseTopologicalOrder() iter.Seq2[ID, T] {
 }
 
 // Helper method to detect cycles using DFS
-func (d *DAG[ID, T]) hasCycle() bool {
+func (d *DAG[ID, T]) hasCycle() ([]ID, bool) {
 	visited := make(map[ID]bool)
 	recStack := make(map[ID]bool)
+	path := make([]ID, 0, len(d.vertices))
+
+	var cycle []ID
 
 	var dfs func(ID) bool
 	dfs = func(vertex ID) bool {
-		if recStack[vertex] {
-			return true // Back edge found, cycle detected
-		}
-		if visited[vertex] {
-			return false // Already processed
-		}
-
 		visited[vertex] = true
 		recStack[vertex] = true
+		path = append(path, vertex)
 
+		neighbors := make([]ID, 0, len(d.edges[vertex]))
 		for neighbor := range d.edges[vertex] {
+			neighbors = append(neighbors, neighbor)
+		}
+		slices.Sort(neighbors)
+
+		for _, neighbor := range neighbors {
+			if recStack[neighbor] {
+				start := slices.Index(path, neighbor)
+				cycle = append([]ID{}, path[start:]...)
+				cycle = append(cycle, neighbor)
+				return true
+			}
+
+			if visited[neighbor] {
+				continue
+			}
+
 			if dfs(neighbor) {
 				return true
 			}
 		}
 
+		path = path[:len(path)-1]
 		recStack[vertex] = false
 		return false
 	}
 
+	vertices := make([]ID, 0, len(d.vertices))
 	for vertex := range d.vertices {
+		vertices = append(vertices, vertex)
+	}
+	slices.Sort(vertices)
+
+	for _, vertex := range vertices {
 		if !visited[vertex] {
 			if dfs(vertex) {
-				return true
+				return cycle, true
 			}
 		}
 	}
 
-	return false
+	return nil, false
 }

--- a/pkg/dag/dag_test.go
+++ b/pkg/dag/dag_test.go
@@ -133,6 +133,11 @@ func TestAddEdge(t *testing.T) {
 		// Try to add edge that creates cycle
 		err = d.AddEdge("C", "A")
 		assert.ErrorIs(t, err, dag.ErrCycleDetected)
+		assert.ErrorContains(t, err, "A -> B -> C -> A")
+
+		var cycleErr *dag.CycleError[string]
+		assert.ErrorAs(t, err, &cycleErr)
+		assert.Equal(t, []string{"A", "B", "C", "A"}, cycleErr.Cycle)
 
 		// Verify the cycle-causing edge was not added
 		assert.False(t, d.EdgeExists("C", "A"))
@@ -147,6 +152,7 @@ func TestAddEdge(t *testing.T) {
 
 		err := d.AddEdge("A", "A")
 		assert.ErrorIs(t, err, dag.ErrCycleDetected)
+		assert.ErrorContains(t, err, "A -> A")
 		assert.False(t, d.EdgeExists("A", "A"))
 		assert.Equal(t, 0, d.GetInDegree("A"))
 	})


### PR DESCRIPTION
## Summary
- add a typed `dag.CycleError` that carries the detected cycle path and still unwraps to `dag.ErrCycleDetected`
- include the service chain in cycle error messages (for example `A -> B -> C -> A`) when an edge introduces a cycle
- add focused DAG and container tests to verify cycle details are present in errors

## Testing
- `go test ./pkg/dag -run TestAddEdge`
- `go test . -run TestContainer_Init`

Closes #42