### PR TITLE
feat: Pal-prefixed lifecycle interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ a few rules described below.
   - [Initer](./lifecycle_interfaces.go#L39) / [PalIniter](./lifecycle_interfaces.go#L84) — one-time setup after dependencies are injected (e.g. open a DB pool). Use `PalInit` when `Init` is already taken.
   - [Shutdowner](./lifecycle_interfaces.go#L20) / [PalShutdowner](./lifecycle_interfaces.go#L75) — cleanup (e.g. close connections). Use `PalShutdown` when `Shutdown` is already taken.
   - [HealthChecker](./lifecycle_interfaces.go#L5) / [PalHealthChecker](./lifecycle_interfaces.go#L66) — liveness logic for probes. Use `PalHealthCheck` when `HealthCheck` is already taken.
+  - [RunConfiger](./interfaces.go#L9) / [PalRunConfiger](./interfaces.go#L17) — optional runner scheduling (`Wait` vs fire-and-forget). Use `PalRunConfig` when `RunConfig` is already taken.
 
-  **Dispatch order** when more than one mechanism could apply: lifecycle hooks (`ToInit`, `ToShutdown`, `ToHealthCheck`) run first; then Pal-prefixed methods if implemented; then the standard `Init` / `Shutdown` / `HealthCheck` methods. For background work, `PalRun` is preferred over `Run` when both exist. In normal use, implement **one** style per phase (standard **or** Pal-prefixed), not both on purpose.
+  **Dispatch order** when more than one mechanism could apply: lifecycle hooks (`ToInit`, `ToShutdown`, `ToHealthCheck`) run first; then Pal-prefixed methods if implemented; then the standard `Init` / `Shutdown` / `HealthCheck` / `RunConfig` methods. For background work, `PalRun` is preferred over `Run` when both exist, and `PalRunConfig` over `RunConfig` when both exist. In normal use, implement **one** style per phase (standard **or** Pal-prefixed), not both on purpose.
 
 ## API Functions
 
@@ -326,6 +327,7 @@ The lifecycle of services and the container in Pal follows a well-defined sequen
 3. **Running**:
    - After initialization, Pal starts all services that implement [Runner](./lifecycle_interfaces.go#L55) or [PalRunner](./lifecycle_interfaces.go#L93) in background goroutines.
    - Pal calls `PalRun` or `Run` (respecting the same precedence as above when both exist) with a context that will be canceled during shutdown.
+   - Runners that implement [RunConfiger](./interfaces.go#L9) or [PalRunConfiger](./interfaces.go#L17) supply scheduling via `RunConfig` or `PalRunConfig` (Pal-prefixed wins if both are present); otherwise a default applies for types that only implement `Run` / `PalRun`.
 
 4. **Health Checking**:
    - Developers can use `Pal.HealthCheck()` to initiate the health check sequence. In a web application it should be called
@@ -385,7 +387,7 @@ The visualization shows:
 
 - Service nodes with their types (singleton, factory)
 - Dependency relationships between services
-- Service capabilities (standard and Pal-prefixed lifecycle interfaces: init, run, health check, shutdown)
+- Service capabilities (standard and Pal-prefixed lifecycle interfaces: init, run, run config, health check, shutdown)
 
 ## Best practices
 

--- a/README.md
+++ b/README.md
@@ -82,18 +82,21 @@ a few rules described below.
   - Singleton service — such services are created only once during application initialization. It can be a client for
     third party service or a piece of business logic. Most of your services should be singletons.
     Pal recognizes a special kind of Singleton service:
-    - [Runner](./interfaces.go#L41) — is a special singleton service that runs in the background. Pal runs such services in
+    - [Runner](./lifecycle_interfaces.go#L55) — is a special singleton service that runs in the background. Pal runs such services in
       the background. Any app should have at least one Runner. For a web service it would be the place where you run
       `http.ListenAndServe(...)`. For a CLI - where the main logic is. `Pal.Run()` exits when all runners are finished.
       Run() will exit immediately if no runners are registered.
+      If another framework already uses `Run` on your type, implement [PalRunner](./lifecycle_interfaces.go#L93) and `PalRun` instead (same behavior).
   - Factory service — a special type of service. Unlike singletons, a new instance of a factory service is created every
     time it is invoked.
   - Const service — a service that wraps an existing instance. It's useful for registering already created objects as services.
 
-  Each service can implement any of optional service interfaces:
-  - [Initer](./interfaces.go#L31) — if a service requires initialization such as connecting to a database.
-  - [`Shutdowner`](./interfaces.go#L20) — if a service requires finalization such as closing connection to a database.
-  - [HealthChecker](./interfaces.go#L10) — if a service can be inspected by checking its database connection status.
+  Each service can implement optional lifecycle interfaces. Prefer the standard names when they do not conflict with other frameworks; otherwise use the Pal-prefixed pair (same semantics, different method names):
+  - [Initer](./lifecycle_interfaces.go#L39) / [PalIniter](./lifecycle_interfaces.go#L84) — one-time setup after dependencies are injected (e.g. open a DB pool). Use `PalInit` when `Init` is already taken.
+  - [Shutdowner](./lifecycle_interfaces.go#L20) / [PalShutdowner](./lifecycle_interfaces.go#L75) — cleanup (e.g. close connections). Use `PalShutdown` when `Shutdown` is already taken.
+  - [HealthChecker](./lifecycle_interfaces.go#L5) / [PalHealthChecker](./lifecycle_interfaces.go#L66) — liveness logic for probes. Use `PalHealthCheck` when `HealthCheck` is already taken.
+
+  **Dispatch order** when more than one mechanism could apply: lifecycle hooks (`ToInit`, `ToShutdown`, `ToHealthCheck`) run first; then Pal-prefixed methods if implemented; then the standard `Init` / `Shutdown` / `HealthCheck` methods. For background work, `PalRun` is preferred over `Run` when both exist. In normal use, implement **one** style per phase (standard **or** Pal-prefixed), not both on purpose.
 
 ## API Functions
 
@@ -317,24 +320,24 @@ The lifecycle of services and the container in Pal follows a well-defined sequen
    - For each service, Pal:
      - Creates an instance
      - Injects dependencies into its fields
-     - Calls `ToInit` hook if specified or the `Init()` method if it implements the Initer interface
-     - If `ToInit` is specified, `Init()` will not be called.
+     - Calls `ToInit` hook if specified; otherwise `PalInit()` if it implements [PalIniter](./lifecycle_interfaces.go#L84), otherwise `Init()` if it implements [Initer](./lifecycle_interfaces.go#L39)
+     - If `ToInit` is specified, neither `PalInit` nor `Init` is called.
 
 3. **Running**:
-   - After initialization, Pal starts all services that implement the `Runner` interface in background goroutines.
-   - The Run() method of these services is called with a context that will be canceled during shutdown.
+   - After initialization, Pal starts all services that implement [Runner](./lifecycle_interfaces.go#L55) or [PalRunner](./lifecycle_interfaces.go#L93) in background goroutines.
+   - Pal calls `PalRun` or `Run` (respecting the same precedence as above when both exist) with a context that will be canceled during shutdown.
 
 4. **Health Checking**:
    - Developers can use `Pal.HealthCheck()` to initiate the health check sequence. In a web application it should be called
      from the `/health` handler which can be used as a liveness probe.
-   - Services may implement their health check logic either by specifying `ToHealthCheck` hook or by implementing the `HealthCheck` method.
-   - If `ToHealthCheck` hook is specified, the `HealthCheck` method will not be called.
+   - Services may implement health checks via `ToHealthCheck`, or via `PalHealthCheck` ([PalHealthChecker](./lifecycle_interfaces.go#L66)), or via `HealthCheck` ([HealthChecker](./lifecycle_interfaces.go#L5)).
+   - If `ToHealthCheck` is specified, neither `PalHealthCheck` nor `HealthCheck` is called.
    - If any service returns an error, Pal initiates a graceful shutdown.
 5. **Shutdown**:
    - When `Pal.Shutdown()` is called or a termination signal is received, Pal initiates the shutdown sequence.
    - Pal cancels the context for all running services (Runners) and awaits for runners to finish.
-   - Pal shuts down dependencies in reverse to initialization order. If `ToShutdown` hook is specified, it's being called, if the service implements `Shutdowner`, the `Shutdown` method will be called.
-   - If `ToShutdown` is specified, the `Shutdown` will not be called.
+   - Pal shuts down dependencies in reverse to initialization order. If `ToShutdown` is set, it runs; otherwise `PalShutdown` or `Shutdown` is used in that precedence order.
+   - If `ToShutdown` is specified, neither `PalShutdown` nor `Shutdown` is called.
    - If all services shut down successfully, `Pal.Run()` returns nil, otherwise it returns the collected errors.
 
 ## Additional features
@@ -382,7 +385,7 @@ The visualization shows:
 
 - Service nodes with their types (singleton, factory)
 - Dependency relationships between services
-- Service capabilities (Initer, Runner, HealthChecker, Shutdowner)
+- Service capabilities (standard and Pal-prefixed lifecycle interfaces: init, run, health check, shutdown)
 
 ## Best practices
 
@@ -391,7 +394,7 @@ To get the most out of Pal, follow these best practices:
 1. **Service Design**:
    - Design services as small, focused components with a single responsibility.
    - Use interfaces to define service contracts, especially for services that might have multiple implementations.
-   - Implement the optional lifecycle interfaces (Initer, `Shutdowner`, HealthChecker) when appropriate.
+   - Implement the optional lifecycle interfaces ([Initer](./lifecycle_interfaces.go#L39), [Shutdowner](./lifecycle_interfaces.go#L20), [HealthChecker](./lifecycle_interfaces.go#L5), or the [Pal-prefixed](./lifecycle_interfaces.go#L66) alternatives when names clash) when appropriate.
    - Use `ProvideConst` and `ProvideFn*` functions with `ToShutdown` hook to register services without dedicated
      interfaces and struct wrappers.
 

--- a/api.go
+++ b/api.go
@@ -12,7 +12,8 @@ import (
 // Typically, `T` would be one of:
 // - An interface, in this case passed value must implement it. Used when T may have multiple implementations like mocks for tests.
 // - A pointer to an instance of `T`. For instance,`Provide[*Foo](&Foo{})`. Used when mocking is not required.
-// If the passed value implements Initer, Init() will be called.
+// If the passed value implements [Initer] or [PalIniter], the matching init method is called after dependency injection,
+// unless a ToInit hook is set on the returned [ServiceConst] (see [ServiceConst.ToInit]).
 func Provide[T any](value T) *ServiceConst[T] {
 	validateNonNilPointer(value)
 

--- a/inspect/static/tree.html
+++ b/inspect/static/tree.html
@@ -42,6 +42,10 @@
         <td class="node-runner"></td>
       </tr>
       <tr>
+        <td>Run config</td>
+        <td class="node-run-configer"></td>
+      </tr>
+      <tr>
         <td>Health Checker</td>
         <td class="node-health-checker"></td>
       </tr>

--- a/inspect/static/tree.js
+++ b/inspect/static/tree.js
@@ -98,6 +98,7 @@ function createNodeTitleTable(node) {
        setValue(".node-out-degree", node.outDegree);
        setValue(".node-initer", node.initer);
        setValue(".node-runner", node.runner);
+       setValue(".node-run-configer", node.runConfiger);
        setValue(".node-health-checker", node.healthChecker);
        setValue(".node-shutdowner", node.shutdowner);
 

--- a/inspect/tree_json.go
+++ b/inspect/tree_json.go
@@ -33,19 +33,27 @@ type EdgeJSON struct {
 func serviceToJSON(id string, inDegree int, outDegree int, service pal.ServiceDef) NodeJSON {
 	var initer, runner, healthChecker, shutdowner bool
 
-	if _, ok := service.Make().(pal.Initer); ok {
+	if _, ok := service.Make().(pal.PalIniter); ok {
+		initer = true
+	} else if _, ok := service.Make().(pal.Initer); ok {
 		initer = true
 	}
 
-	if _, ok := service.Make().(pal.Runner); ok {
+	if _, ok := service.Make().(pal.PalRunner); ok {
+		runner = true
+	} else if _, ok := service.Make().(pal.Runner); ok {
 		runner = true
 	}
 
-	if _, ok := service.Make().(pal.HealthChecker); ok {
+	if _, ok := service.Make().(pal.PalHealthChecker); ok {
+		healthChecker = true
+	} else if _, ok := service.Make().(pal.HealthChecker); ok {
 		healthChecker = true
 	}
 
-	if _, ok := service.Make().(pal.Shutdowner); ok {
+	if _, ok := service.Make().(pal.PalShutdowner); ok {
+		shutdowner = true
+	} else if _, ok := service.Make().(pal.Shutdowner); ok {
 		shutdowner = true
 	}
 

--- a/inspect/tree_json.go
+++ b/inspect/tree_json.go
@@ -21,6 +21,7 @@ type NodeJSON struct {
 
 	Initer        bool `json:"initer"`
 	Runner        bool `json:"runner"`
+	RunConfiger   bool `json:"runConfiger"`
 	HealthChecker bool `json:"healthChecker"`
 	Shutdowner    bool `json:"shutdowner"`
 }
@@ -31,7 +32,7 @@ type EdgeJSON struct {
 }
 
 func serviceToJSON(id string, inDegree int, outDegree int, service pal.ServiceDef) NodeJSON {
-	var initer, runner, healthChecker, shutdowner bool
+	var initer, runner, runConfiger, healthChecker, shutdowner bool
 
 	if _, ok := service.Make().(pal.PalIniter); ok {
 		initer = true
@@ -43,6 +44,12 @@ func serviceToJSON(id string, inDegree int, outDegree int, service pal.ServiceDe
 		runner = true
 	} else if _, ok := service.Make().(pal.Runner); ok {
 		runner = true
+	}
+
+	if _, ok := service.Make().(pal.PalRunConfiger); ok {
+		runConfiger = true
+	} else if _, ok := service.Make().(pal.RunConfiger); ok {
+		runConfiger = true
 	}
 
 	if _, ok := service.Make().(pal.PalHealthChecker); ok {
@@ -72,6 +79,7 @@ func serviceToJSON(id string, inDegree int, outDegree int, service pal.ServiceDe
 
 		Initer:        initer,
 		Runner:        runner,
+		RunConfiger:   runConfiger,
 		HealthChecker: healthChecker,
 		Shutdowner:    shutdowner,
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,9 +10,17 @@ type RunConfiger interface {
 	RunConfig() *RunConfig
 }
 
+// PalRunConfiger is an alternaltive interface with the same semantics as [RunConfiger], using a Pal-prefixed method name
+// so the type can still implement another framework's RunConfig without a clash.
+// Prefer [RunConfiger] when method names do not conflict.
+// If both PalRunConfiger and [RunConfiger] are implemented, Pal uses [PalRunConfiger.PalRunConfig] only.
+type PalRunConfiger interface { //nolint:revive
+	PalRunConfig() *RunConfig
+}
+
 // ServiceDef is a definition of a service. In the case of a singleton service, it also holds the instance.
 // This interface embeds the standard lifecycle interfaces ([Initer], [HealthChecker], [Shutdowner], [Runner]);
-// concrete services may instead implement the Pal-prefixed alternatives ([PalIniter], [PalHealthChecker], [PalShutdowner], [PalRunner]) where method names would otherwise clash.
+// concrete services may instead implement the Pal-prefixed alternatives ([PalIniter], [PalHealthChecker], [PalShutdowner], [PalRunner], [PalRunConfiger]) where method names would otherwise clash.
 // It adds methods specific to service definition and management.
 type ServiceDef interface {
 	Initer

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,8 +11,9 @@ type RunConfiger interface {
 }
 
 // ServiceDef is a definition of a service. In the case of a singleton service, it also holds the instance.
-// This interface combines all the lifecycle interfaces (Initer, HealthChecker, Shutdowner, Runner)
-// and adds methods specific to service definition and management.
+// This interface embeds the standard lifecycle interfaces ([Initer], [HealthChecker], [Shutdowner], [Runner]);
+// concrete services may instead implement the Pal-prefixed alternatives ([PalIniter], [PalHealthChecker], [PalShutdowner], [PalRunner]) where method names would otherwise clash.
+// It adds methods specific to service definition and management.
 type ServiceDef interface {
 	Initer
 	HealthChecker

--- a/lifecycle_interfaces.go
+++ b/lifecycle_interfaces.go
@@ -62,3 +62,39 @@ type Runner interface {
 	// If this method returns an error, Pal will initiate a graceful shutdown of the application.
 	Run(ctx context.Context) error
 }
+
+// PalHealthChecker is an anternative interface with the same semantics as [HealthChecker], using a Pal-prefixed method name
+// so the type can still implement another framework's HealthCheck (or similar) without a clash.
+// Prefer [HealthChecker] when method names do not conflict.
+// If both PalHealthChecker and [HealthChecker] are implemented, Pal calls [PalHealthChecker.PalHealthCheck] only.
+type PalHealthChecker interface { //nolint:revive
+	// PalHealthCheck is equivalent to [HealthChecker.HealthCheck]; see that method's documentation.
+	PalHealthCheck(ctx context.Context) error
+}
+
+// PalShutdowner is an anternative interface with the same semantics as [Shutdowner], using a Pal-prefixed method name
+// so the type can still implement another framework's Shutdown without a clash.
+// Prefer [Shutdowner] when method names do not conflict.
+// If both PalShutdowner and [Shutdowner] are implemented, Pal calls [PalShutdowner.PalShutdown] only.
+type PalShutdowner interface { //nolint:revive
+	// PalShutdown is equivalent to [Shutdowner.Shutdown]; see that method's documentation.
+	PalShutdown(ctx context.Context) error
+}
+
+// PalIniter is an anternative interface with the same semantics as [Initer], using a Pal-prefixed method name
+// so the type can still implement another framework's Init without a clash.
+// Prefer [Initer] when method names do not conflict.
+// If both PalIniter and [Initer] are implemented, Pal calls [PalIniter.PalInit] only.
+type PalIniter interface { //nolint:revive
+	// PalInit is equivalent to [Initer.Init]; see that method's documentation.
+	PalInit(ctx context.Context) error
+}
+
+// PalRunner is an anternative interface with the same semantics as [Runner], using a Pal-prefixed method name
+// so the type can still implement another framework's Run without a clash.
+// Prefer [Runner] when method names do not conflict.
+// If both PalRunner and [Runner] are implemented, Pal calls [PalRunner.PalRun] only.
+type PalRunner interface { //nolint:revive
+	// PalRun is equivalent to [Runner.Run]; see that method's documentation.
+	PalRun(ctx context.Context) error
+}

--- a/pal_prefixed_lifecycle_test.go
+++ b/pal_prefixed_lifecycle_test.go
@@ -1,0 +1,146 @@
+package pal_test
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zhulik/pal"
+)
+
+// palOnlyLifecycle implements only Pal-prefixed lifecycle methods.
+type palOnlyLifecycle struct {
+	palInit, palHealth, palShutdown bool
+}
+
+func (s *palOnlyLifecycle) PalInit(_ context.Context) error {
+	s.palInit = true
+	return nil
+}
+
+func (s *palOnlyLifecycle) PalHealthCheck(_ context.Context) error {
+	s.palHealth = true
+	return nil
+}
+
+func (s *palOnlyLifecycle) PalShutdown(_ context.Context) error {
+	s.palShutdown = true
+	return nil
+}
+
+func TestPalPrefixed_palOnlyInitHealthShutdown(t *testing.T) {
+	t.Parallel()
+
+	s := &palOnlyLifecycle{}
+	p := newPal(pal.Provide(s))
+
+	require.NoError(t, p.Init(t.Context()))
+	assert.True(t, s.palInit, "PalInit should run when only PalIniter is implemented")
+
+	ctx := pal.WithPal(t.Context(), p)
+	require.NoError(t, p.HealthCheck(ctx))
+	assert.True(t, s.palHealth, "PalHealthCheck should run when only PalHealthChecker is implemented")
+
+	require.NoError(t, p.Container().Shutdown(ctx))
+	assert.True(t, s.palShutdown, "PalShutdown should run when only PalShutdowner is implemented")
+}
+
+// dualInitHealthShutdown implements both standard and Pal-prefixed lifecycle methods.
+type dualInitHealthShutdown struct {
+	palInit, stdInit           bool
+	palHealth, stdHealth       bool
+	palShutdown, stdShutdown   bool
+	palRunCalled, stdRunCalled bool
+}
+
+func (d *dualInitHealthShutdown) PalInit(_ context.Context) error {
+	d.palInit = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) Init(_ context.Context) error {
+	d.stdInit = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) PalHealthCheck(_ context.Context) error {
+	d.palHealth = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) HealthCheck(_ context.Context) error {
+	d.stdHealth = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) PalShutdown(_ context.Context) error {
+	d.palShutdown = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) Shutdown(_ context.Context) error {
+	d.stdShutdown = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) PalRun(_ context.Context) error {
+	d.palRunCalled = true
+	return nil
+}
+
+func (d *dualInitHealthShutdown) Run(_ context.Context) error {
+	d.stdRunCalled = true
+	return nil
+}
+
+func TestPalPrefixed_precedenceOverStandardMethods(t *testing.T) {
+	t.Parallel()
+
+	s := &dualInitHealthShutdown{}
+	p := newPal(pal.Provide(s))
+
+	require.NoError(t, p.Init(t.Context()))
+	assert.True(t, s.palInit)
+	assert.False(t, s.stdInit)
+
+	ctx := pal.WithPal(t.Context(), p)
+	require.NoError(t, p.HealthCheck(ctx))
+	assert.True(t, s.palHealth)
+	assert.False(t, s.stdHealth)
+
+	require.NoError(t, p.Container().Shutdown(ctx))
+	assert.True(t, s.palShutdown)
+	assert.False(t, s.stdShutdown)
+
+	require.NoError(t, p.Run(t.Context(), syscall.SIGINT))
+	assert.True(t, s.palRunCalled)
+	assert.False(t, s.stdRunCalled)
+}
+
+type palInitWithHook struct {
+	palInitCalled bool
+}
+
+func (s *palInitWithHook) PalInit(_ context.Context) error {
+	s.palInitCalled = true
+	return nil
+}
+
+func TestPalPrefixed_ToInitHookOverridesPalInit(t *testing.T) {
+	t.Parallel()
+
+	s := &palInitWithHook{}
+	hookCalled := false
+
+	p := newPal(pal.Provide(s).ToInit(func(_ context.Context, _ *palInitWithHook, _ *pal.Pal) error {
+		hookCalled = true
+		return nil
+	}))
+
+	require.NoError(t, p.Init(t.Context()))
+	assert.True(t, hookCalled)
+	assert.False(t, s.palInitCalled, "PalInit must not run when ToInit hook is set")
+}

--- a/pal_prefixed_lifecycle_test.go
+++ b/pal_prefixed_lifecycle_test.go
@@ -129,6 +129,56 @@ func (s *palInitWithHook) PalInit(_ context.Context) error {
 	return nil
 }
 
+type dualRunConfig struct {
+	palChosen, stdChosen bool
+}
+
+func (d *dualRunConfig) PalRunConfig() *pal.RunConfig {
+	d.palChosen = true
+	return &pal.RunConfig{Wait: true}
+}
+
+func (d *dualRunConfig) RunConfig() *pal.RunConfig {
+	d.stdChosen = true
+	return &pal.RunConfig{Wait: false}
+}
+
+func (d *dualRunConfig) Run(_ context.Context) error {
+	return nil
+}
+
+func TestPalPrefixed_runConfigPalWinsOverStandard(t *testing.T) {
+	t.Parallel()
+
+	d := &dualRunConfig{}
+	svc := pal.Provide(d)
+	cfg := svc.RunConfig()
+	require.NotNil(t, cfg)
+	assert.True(t, cfg.Wait, "PalRunConfig should take precedence over RunConfig")
+	assert.True(t, d.palChosen)
+	assert.False(t, d.stdChosen)
+}
+
+type palOnlyRunConfig struct{}
+
+func (p *palOnlyRunConfig) PalRunConfig() *pal.RunConfig {
+	return &pal.RunConfig{Wait: false}
+}
+
+func (p *palOnlyRunConfig) Run(_ context.Context) error {
+	return nil
+}
+
+func TestPalPrefixed_palRunConfigOnly(t *testing.T) {
+	t.Parallel()
+
+	s := &palOnlyRunConfig{}
+	svc := pal.Provide(s)
+	cfg := svc.RunConfig()
+	require.NotNil(t, cfg)
+	assert.False(t, cfg.Wait)
+}
+
 func TestPalPrefixed_ToInitHookOverridesPalInit(t *testing.T) {
 	t.Parallel()
 

--- a/service_const.go
+++ b/service_const.go
@@ -15,9 +15,8 @@ type ServiceConst[T any] struct {
 }
 
 func (c *ServiceConst[T]) RunConfig() *RunConfig {
-	configer, ok := any(c.instance).(RunConfiger)
-	if ok {
-		return configer.RunConfig()
+	if cfg := palOrStandardRunConfig(any(c.instance)); cfg != nil {
+		return cfg
 	}
 
 	if _, ok := any(c.instance).(PalRunner); ok {

--- a/service_const.go
+++ b/service_const.go
@@ -20,6 +20,9 @@ func (c *ServiceConst[T]) RunConfig() *RunConfig {
 		return configer.RunConfig()
 	}
 
+	if _, ok := any(c.instance).(PalRunner); ok {
+		return defaultRunConfig
+	}
 	if _, ok := any(c.instance).(Runner); ok {
 		return defaultRunConfig
 	}
@@ -60,8 +63,7 @@ func (c *ServiceConst[T]) Instance(_ context.Context, _ ...any) (any, error) {
 
 // ToInit registers a hook function that will be called to initialize the service.
 // This hook is called after the service is injected with its dependencies.
-// If the service implements the Initer interface, the Init() method is not called,
-// the hook has higher priority.
+// If the service implements [PalIniter] or [Initer], those init methods are not called; the hook has higher priority.
 func (c *ServiceConst[T]) ToInit(hook LifecycleHook[T]) *ServiceConst[T] {
 	c.hooks.Init = hook
 	return c
@@ -69,16 +71,14 @@ func (c *ServiceConst[T]) ToInit(hook LifecycleHook[T]) *ServiceConst[T] {
 
 // ToShutdown registers a hook function that will be called to shutdown the service.
 // This hook is called before service's dependencies are shutdown.
-// If the service implements the Shutdowner interface, the Shutdown() method is not called,
-// the hook has higher priority.
+// If the service implements [PalShutdowner] or [Shutdowner], those shutdown methods are not called; the hook has higher priority.
 func (c *ServiceConst[T]) ToShutdown(hook LifecycleHook[T]) *ServiceConst[T] {
 	c.hooks.Shutdown = hook
 	return c
 }
 
 // ToHealthCheck registers a hook function that will be called to perform a health check on the service.
-// If the service implements the HealthChecker interface, the HealthCheck() method is not called,
-// the hook has higher priority.
+// If the service implements [PalHealthChecker] or [HealthChecker], those health check methods are not called; the hook has higher priority.
 func (c *ServiceConst[T]) ToHealthCheck(hook LifecycleHook[T]) *ServiceConst[T] {
 	c.hooks.HealthCheck = hook
 	return c

--- a/service_fn_singleton.go
+++ b/service_fn_singleton.go
@@ -16,9 +16,8 @@ type ServiceFnSingleton[I, T any] struct {
 }
 
 func (c *ServiceFnSingleton[I, T]) RunConfig() *RunConfig {
-	configer, ok := any(c.instance).(RunConfiger)
-	if ok {
-		return configer.RunConfig()
+	if cfg := palOrStandardRunConfig(any(c.instance)); cfg != nil {
+		return cfg
 	}
 
 	if _, ok := c.Make().(PalRunner); ok {

--- a/service_fn_singleton.go
+++ b/service_fn_singleton.go
@@ -21,6 +21,9 @@ func (c *ServiceFnSingleton[I, T]) RunConfig() *RunConfig {
 		return configer.RunConfig()
 	}
 
+	if _, ok := c.Make().(PalRunner); ok {
+		return defaultRunConfig
+	}
 	if _, ok := c.Make().(Runner); ok {
 		return defaultRunConfig
 	}
@@ -40,7 +43,11 @@ func (c *ServiceFnSingleton[I, T]) Init(ctx context.Context) error {
 		return err
 	}
 
-	if initer, ok := any(instance).(Initer); ok {
+	if pi, ok := any(instance).(PalIniter); ok {
+		if err := pi.PalInit(ctx); err != nil {
+			return err
+		}
+	} else if initer, ok := any(instance).(Initer); ok {
 		if err := initer.Init(ctx); err != nil {
 			return err
 		}
@@ -66,14 +73,15 @@ func (c *ServiceFnSingleton[I, T]) Instance(_ context.Context, _ ...any) (any, e
 	return c.instance, nil
 }
 
+// ToShutdown registers a hook called during shutdown. If the service implements [PalShutdowner] or [Shutdowner],
+// those methods are not called; the hook has higher priority.
 func (c *ServiceFnSingleton[I, T]) ToShutdown(hook LifecycleHook[T]) *ServiceFnSingleton[I, T] {
 	c.hooks.Shutdown = hook
 	return c
 }
 
 // ToHealthCheck registers a hook function that will be called to perform a health check on the service.
-// If the service implements the HealthChecker interface, the HealthCheck() method is not called,
-// the hook has higher priority.
+// If the service implements [PalHealthChecker] or [HealthChecker], those health check methods are not called; the hook has higher priority.
 func (c *ServiceFnSingleton[I, T]) ToHealthCheck(hook LifecycleHook[T]) *ServiceFnSingleton[I, T] {
 	c.hooks.HealthCheck = hook
 	return c

--- a/services.go
+++ b/services.go
@@ -170,6 +170,18 @@ func flattenServices(services []ServiceDef) []ServiceDef {
 	return result
 }
 
+// palOrStandardRunConfig returns scheduling config from a service instance when it implements
+// [PalRunConfiger] or [RunConfiger]; otherwise nil.
+func palOrStandardRunConfig(instance any) *RunConfig {
+	if pc, ok := instance.(PalRunConfiger); ok {
+		return pc.PalRunConfig()
+	}
+	if c, ok := instance.(RunConfiger); ok {
+		return c.RunConfig()
+	}
+	return nil
+}
+
 func getRunners(services []ServiceDef) ([]ServiceDef, []ServiceDef) {
 	mainRunners := []ServiceDef{}
 	secondaryRunners := []ServiceDef{}

--- a/services.go
+++ b/services.go
@@ -7,22 +7,35 @@ import (
 
 func runService(ctx context.Context, name string, instance any, p *Pal) error {
 	logger := p.logger.With("service", name)
-	runner, ok := instance.(Runner)
-	if !ok {
+
+	var run func() error
+	if pr, ok := instance.(PalRunner); ok {
+		run = func() error {
+			logger.Debug("Running")
+			err := pr.PalRun(ctx)
+			if err != nil {
+				logger.Error("Runner exited with error", "error", err)
+				return err
+			}
+			logger.Debug("Runner finished successfully")
+			return nil
+		}
+	} else if runner, ok := instance.(Runner); ok {
+		run = func() error {
+			logger.Debug("Running")
+			err := runner.Run(ctx)
+			if err != nil {
+				logger.Error("Runner exited with error", "error", err)
+				return err
+			}
+			logger.Debug("Runner finished successfully")
+			return nil
+		}
+	} else {
 		return nil
 	}
 
-	err := tryWrap(func() error {
-		logger.Debug("Running")
-		err := runner.Run(ctx)
-		if err != nil {
-			logger.Error("Runner exited with error", "error", err)
-			return err
-		}
-
-		logger.Debug("Runner finished successfully")
-		return nil
-	})()
+	err := tryWrap(run)()
 
 	if err != nil {
 		if panicErr, ok := err.(*PanicError); ok {
@@ -40,6 +53,14 @@ func healthcheckService[T any](ctx context.Context, name string, instance T, hoo
 		err := hook(ctx, instance, p)
 		if err != nil {
 			logger.Error("Healthcheck hook failed", "error", err)
+		}
+		return err
+	}
+
+	if ph, ok := any(instance).(PalHealthChecker); ok {
+		err := ph.PalHealthCheck(ctx)
+		if err != nil {
+			logger.Error("Healthcheck failed", "error", err)
 		}
 		return err
 	}
@@ -65,6 +86,14 @@ func shutdownService[T any](ctx context.Context, name string, instance T, hook L
 		err := hook(ctx, instance, p)
 		if err != nil {
 			logger.Error("Shutdown hook failed", "error", err)
+		}
+		return err
+	}
+
+	if ps, ok := any(instance).(PalShutdowner); ok {
+		err := ps.PalShutdown(ctx)
+		if err != nil {
+			logger.Error("Shutdown failed", "error", err)
 		}
 		return err
 	}
@@ -100,6 +129,14 @@ func initService[T any](ctx context.Context, name string, instance T, hook Lifec
 		return err
 	}
 
+	if pi, ok := any(instance).(PalIniter); ok && any(instance) != any(p) {
+		logger.Debug("Calling PalInit method")
+		if err := pi.PalInit(ctx); err != nil {
+			logger.Error("Init failed", "error", err)
+			return err
+		}
+		return nil
+	}
 	if initer, ok := any(instance).(Initer); ok && any(instance) != any(p) {
 		logger.Debug("Calling Init method")
 		if err := initer.Init(ctx); err != nil {


### PR DESCRIPTION
## Summary

Adds optional Pal-prefixed lifecycle hooks so services can participate in Pal’s init / run / shutdown / health / **run scheduling** when another framework already uses overlapping method names (`Init`, `Run`, `Shutdown`, `HealthCheck`, `RunConfig`). Standard interfaces remain first-class; Pal-prefixed types are additive and coequal. Dispatch order when multiple mechanisms apply: **hooks → Pal-prefixed methods → standard methods**.

Closes #25.

## Changes

- **Lifecycle:** `PalIniter`, `PalRunner`, `PalShutdowner`, `PalHealthChecker` in `lifecycle_interfaces.go`; central dispatch in `services.go`; `RunConfig` / `ServiceFnSingleton.Init` updates; inspector capability flags; README and package docs; tests for Pal-only, precedence vs standard methods, and hooks over `PalInit`.
- **Run scheduling:** `PalRunConfiger` with `PalRunConfig()` in `interfaces.go`; `palOrStandardRunConfig` helper; `ServiceConst` / `ServiceFnSingleton` `RunConfig()`; inspector JSON field `runConfiger` plus tree tooltip row; README glossary and running section; tests `TestPalPrefixed_runConfigPalWinsOverStandard` and `TestPalPrefixed_palRunConfigOnly`.

## How To Test

```bash
go test ./...
go vet ./...
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact
