### PR TITLE
feat(cli): teach cli scaffold interface-based DI via greeter

### DIFF
--- a/.cursor/rules/pal-cli.mdc
+++ b/.cursor/rules/pal-cli.mdc
@@ -136,6 +136,8 @@ templates/scaffolds/cli/.gitignore.tmpl                →  .gitignore
 
 Do not invent a second templating dialect (e.g. cookiecutter, custom `{{name}}` tokens). Extend `templates.Data` when new fields are needed, and keep path + content rendering on `text/template`. Do not add scaffold files without the `.tmpl` suffix.
 
+**`cli` scaffold shape:** demonstrate interface-based DI, not a bare long-running runner. Layout is `cmd/{{.Package}}` (entrypoint) + `internal/core` (shared interfaces) + `internal/greeter` (`Provide()` returning `pal.Provide[core.Greeter](…)`). The runner injects `core.Greeter` and `*slog.Logger`, implements `pal.Initer` / `Runner` / `Shutdowner` (with compile-time `_ pal.X = (*runner)(nil)` checks), and `Run` prints a greeting then returns — it does **not** block on `<-ctx.Done()`. Keep README layout/docs in sync with that tree and one-shot Run behavior.
+
 ## Frozen public surface
 
 These names are **frozen** — extend by adding, do not rename without a deliberate breaking-change decision:

--- a/cmd/pal/templates/scaffolds/cli/README.md.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/README.md.tmpl
@@ -41,13 +41,16 @@ task cover
 
 ```
 .
-├── cmd/{{.Package}}/   # application entrypoint
-├── Taskfile.yaml       # test, lint, run
-├── .golangci.yaml      # linter config
+├── cmd/{{.Package}}/      # application entrypoint
+├── internal/
+│   ├── core/              # shared interfaces
+│   └── greeter/           # sample greeter service
+├── Taskfile.yaml          # test, lint, run
+├── .golangci.yaml         # linter config
 └── .gitignore
 ```
 
-The entrypoint wires a service with `Init` / `Run` / `Shutdown` logging, slog
-injection, and standard init / health-check / shutdown timeouts. `Run` blocks
-until the process is interrupted. Extend it by providing more services to
-`pal.New` and injecting them into your runner.
+The entrypoint wires a runner and a greeter service with `Init` / `Run` /
+`Shutdown` logging, slog injection, and standard timeouts. `Run` prints a
+greeting from the injected greeter and exits. Extend it by providing more
+services to `pal.New` and injecting them into your runner.

--- a/cmd/pal/templates/scaffolds/cli/cmd/{{.Package}}/main.go.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/cmd/{{.Package}}/main.go.tmpl
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/zhulik/pal"
+
+	"{{ .Module }}/internal/core"
+	"{{ .Module }}/internal/greeter"
 )
 
 var (
@@ -18,7 +21,8 @@ var (
 )
 
 type runner struct {
-	Logger *slog.Logger
+	Greeter core.Greeter
+	Logger  *slog.Logger
 }
 
 //nolint:unparam // demo Init always succeeds
@@ -27,10 +31,10 @@ func (r *runner) Init(_ context.Context) error {
 	return nil
 }
 
-//nolint:unparam // demo Run waits for cancel then succeeds
-func (r *runner) Run(ctx context.Context) error {
+//nolint:unparam // demo Run prints a message from the greeter service
+func (r *runner) Run(_ context.Context) error {
 	r.Logger.Info("{{.Package}} running")
-	<-ctx.Done()
+	r.Logger.Info("{{.Package}} message", "message", r.Greeter.SayHello("World"))
 	return nil
 }
 
@@ -43,6 +47,7 @@ func (r *runner) Shutdown(_ context.Context) error {
 func main() {
 	p := pal.New(
 		pal.Provide(&runner{}),
+		greeter.Provide(),
 	).
 		InjectSlog().
 		InitTimeout(time.Second).

--- a/cmd/pal/templates/scaffolds/cli/internal/core/interfaces.go.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/internal/core/interfaces.go.tmpl
@@ -1,0 +1,6 @@
+package core
+
+// Greeter greets a named recipient.
+type Greeter interface {
+	SayHello(name string) string
+}

--- a/cmd/pal/templates/scaffolds/cli/internal/greeter/greeter.go.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/internal/greeter/greeter.go.tmpl
@@ -1,0 +1,7 @@
+package greeter
+
+type Greeter struct{}
+
+func (g *Greeter) SayHello(name string) string {
+	return "Hello, " + name
+}

--- a/cmd/pal/templates/scaffolds/cli/internal/greeter/services.go.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/internal/greeter/services.go.tmpl
@@ -1,0 +1,11 @@
+package greeter
+
+import (
+	"github.com/zhulik/pal"
+
+	"{{ .Module }}/internal/core"
+)
+
+func Provide() pal.ServiceDef {
+	return pal.Provide[core.Greeter](&Greeter{})
+}

--- a/cmd/pal/templates/templates_test.go
+++ b/cmd/pal/templates/templates_test.go
@@ -58,12 +58,15 @@ func TestApplyCLI(t *testing.T) {
 	require.Contains(t, string(data), "package main")
 	require.Contains(t, string(data), "Package main is the myapp CLI entrypoint")
 	require.Contains(t, string(data), "pal.Initer")
+	require.Contains(t, string(data), "core.Greeter")
+	require.Contains(t, string(data), "greeter.Provide()")
+	require.Contains(t, string(data), `r.Greeter.SayHello("World")`)
 	require.Contains(t, string(data), `"myapp initializing"`)
 	require.Contains(t, string(data), `"myapp running"`)
 	require.Contains(t, string(data), `"myapp shutting down"`)
-	require.Contains(t, string(data), "<-ctx.Done()")
 	require.Contains(t, string(data), "//nolint:unparam")
 	require.NotContains(t, string(data), "{{.Package}}")
+	require.NotContains(t, string(data), "{{ .Module }}")
 
 	for _, rel := range []string{
 		"README.md",
@@ -71,12 +74,21 @@ func TestApplyCLI(t *testing.T) {
 		"Taskfile.yaml",
 		".golangci.yaml",
 		".tool-versions",
+		"internal/core/interfaces.go",
+		"internal/greeter/greeter.go",
+		"internal/greeter/services.go",
 	} {
 		path := filepath.Join(dir, rel)
 		_, err := os.Stat(path)
 		require.NoError(t, err, "expected scaffold file %s", rel)
 		require.False(t, strings.HasSuffix(path, ".tmpl"))
 	}
+
+	greeterServices, err := os.ReadFile(filepath.Join(dir, "internal", "greeter", "services.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(greeterServices), "pal.Provide[core.Greeter]")
+	require.Contains(t, string(greeterServices), "example.com/myapp/internal/core")
+	require.NotContains(t, string(greeterServices), "{{.")
 
 	toolVersions, err := os.ReadFile(filepath.Join(dir, ".tool-versions"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Update the `cli` project scaffold to demonstrate interface-based DI with a sample greeter service, instead of a long-running `<-ctx.Done()` runner.

## Changes

- Add `internal/core` + `internal/greeter` to the `cli` scaffold (`Provide[core.Greeter]`)
- Wire the runner to inject `core.Greeter` and print a greeting on `Run` (one-shot exit)
- Align scaffold README, template tests, and CLI agent rules with the new shape

## How To Test

```bash
cd cmd/pal && task test && task lint-fix
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact
