### PR TITLE
feat(cli): improve cli scaffold and add description step

### DIFF
--- a/.cursor/rules/pal-cli.mdc
+++ b/.cursor/rules/pal-cli.mdc
@@ -68,6 +68,7 @@ Wire `Command.Version` on the root to `version.String()`. `-v` / `--version` use
 - Wizard library: **charmbracelet/huh**.
 - Go module path is a positional argument (`pal init github.com/user/app`), not a flag. Required in non-interactive mode. When provided on the CLI, the wizard skips the module step.
 - Project template is `--template` (default `cli`). The wizard asks unless `--template` was **explicitly** set on the CLI (`cmd.IsSet`); the flag default alone does not skip the step.
+- Project description is `--description`. Empty / omitted means unset: the wizard asks, and an empty value (CLI or wizard) is replaced with `//TODO: add description` before apply. A non-empty value skips the wizard step. The value is passed through `templates.Data.Description` into README, AGENTS.md, the PR template, and other docs.
 - `--no-git` skips the git wizard step when explicitly set; otherwise the wizard asks (default yes).
 - **`--directory` / `-d`** is a path override (CLI-only, not a Step — same class as `--no-interactive`). Applies to both interactive and non-interactive modes. Empty/omitted means the process cwd. The target must be missing or an existing **empty** directory (`ErrNotEmpty` otherwise; no `--force`).
 
@@ -84,7 +85,7 @@ Init never mutates the target until the project is fully built:
 
 Do not write into an existing empty target (or cwd) in place — that left half-inits when a later step failed. Staging + promote is the only write path.
 
-Pass the full `Options` from the CLI into `RunWizard` — never reseed with a partial struct (e.g. only `Module`). Steps that track “explicitly set on CLI” use `IsSet` flags on `Options` (`TemplateSet`, `GitSet`) so flag defaults do not suppress prompts.
+Pass the full `Options` from the CLI into `RunWizard` — never reseed with a partial struct (e.g. only `Module`). Steps that track “explicitly set on CLI” use `IsSet` flags on `Options` (`TemplateSet`, `GitSet`) so flag defaults do not suppress prompts. Description is different: a non-empty `Options.Description` skips the step; empty is filled with the default after the wizard (or in non-interactive mode) before apply.
 
 ## Step registry (keep CLI ↔ wizard in sync)
 
@@ -95,8 +96,8 @@ Each init concern is a `Step` owning both a CLI input (flag **or** positional ar
 | Kind | Pattern | Examples |
 |------|---------|----------|
 | Registry file | `wizard_steps.go` | `Step` interface + `Steps()` |
-| Step file | `wizard_step_<concern>.go` | `wizard_step_module.go`, `wizard_step_git.go`, `wizard_step_template.go` |
-| Step type | `wizardStep<Concern>` | `wizardStepModule`, `wizardStepGit`, `wizardStepTemplate` |
+| Step file | `wizard_step_<concern>.go` | `wizard_step_module.go`, `wizard_step_description.go`, `wizard_step_git.go`, `wizard_step_template.go` |
+| Step type | `wizardStep<Concern>` | `wizardStepModule`, `wizardStepDescription`, `wizardStepGit`, `wizardStepTemplate` |
 
 Do not name step files after the concern alone (`module.go`, `git.go`) — that collides with runner helpers and hides that the type is a wizard/CLI step. Related backend helpers for a concern (e.g. `initGit`, `applyTemplate`) may live in the same `wizard_step_*.go` file.
 
@@ -151,6 +152,7 @@ These names are **frozen** — extend by adding, do not rename without a deliber
 | Mode flag | `--no-interactive` |
 | Path flag | `--directory` / `-d` |
 | Template flag | `--template` (default / id `cli`) |
+| Description flag | `--description` (empty → `//TODO: add description`) |
 | Git flag | `--no-git` |
 | Module input | positional `MODULE` |
 | Templating | Go `text/template` + `templates.Data` fields only |

--- a/.cursor/rules/pal-cli.mdc
+++ b/.cursor/rules/pal-cli.mdc
@@ -124,7 +124,7 @@ The wizard template select and non-interactive validation both use `templates.Na
 
 Scaffold docs that mention a Go version (e.g. README Requirements) must match the **pal library** `go` directive in the root `go.mod`, not an outdated minimum.
 
-**Templating:** every file path segment and every file’s contents under a template are Go `text/template` templates. Supported `templates.Data` fields: `.Package` (module path’s last element, `-` → `_`) and `.Module` (full module path).
+**Templating:** every file path segment and every file’s contents under a template are Go `text/template` templates. Supported `templates.Data` fields: `.Package` (module path’s last element, `-` → `_`), `.Module` (full module path), and `.Description` (short project blurb for docs).
 
 **Every scaffold file must end with `.tmpl`.** This is required for all files (Go sources, README, Taskfile, configs, `.gitignore`, …), not only sources that would confuse `go test`/`go list`. `Apply` strips a trailing `.tmpl` from the output path. Example layout:
 
@@ -137,6 +137,8 @@ templates/scaffolds/cli/.gitignore.tmpl                →  .gitignore
 Do not invent a second templating dialect (e.g. cookiecutter, custom `{{name}}` tokens). Extend `templates.Data` when new fields are needed, and keep path + content rendering on `text/template`. Do not add scaffold files without the `.tmpl` suffix.
 
 **`cli` scaffold shape:** demonstrate interface-based DI, not a bare long-running runner. Layout is `cmd/{{.Package}}` (entrypoint) + `internal/core` (shared interfaces) + `internal/greeter` (`Provide()` returning `pal.Provide[core.Greeter](…)`). The runner injects `core.Greeter` and `*slog.Logger`, implements `pal.Initer` / `Runner` / `Shutdowner` (with compile-time `_ pal.X = (*runner)(nil)` checks), and `Run` prints a greeting then returns — it does **not** block on `<-ctx.Done()`. Keep README layout/docs in sync with that tree and one-shot Run behavior.
+
+Also ship: `AGENTS.md` (testing conventions: external `*_test` packages, testify `require`/`assert`), `.github/pull_request_template.md`, and `.github/workflows/ci.yaml` (asdf setup + plugins from `.tool-versions`, then `task check`). Scaffold Taskfile must expose a `check` task (lint + test) as the CI entrypoint.
 
 ## Frozen public surface
 

--- a/cmd/pal/internal/cli/subscommands/init/options.go
+++ b/cmd/pal/internal/cli/subscommands/init/options.go
@@ -24,6 +24,10 @@ type Options struct {
 	Git bool
 	// GitSet is true when --no-git was explicitly passed on the CLI.
 	GitSet bool
+	// Description is a short project blurb for README, AGENTS.md, and other
+	// docs. Empty means unset (wizard asks; apply falls back to
+	// "//TODO: add description"). A non-empty value skips the wizard step.
+	Description string
 }
 
 // Args returns the CLI arguments equivalent to the project options
@@ -38,6 +42,9 @@ func (o Options) Args() []string {
 	}
 	if o.Template != "" && o.Template != defaultTemplate {
 		args = append(args, "--"+flagTemplate, o.Template)
+	}
+	if o.Description != "" && o.Description != defaultDescription {
+		args = append(args, "--"+flagDescription, o.Description)
 	}
 	if !o.Git {
 		args = append(args, "--"+flagNoGit)
@@ -55,5 +62,6 @@ func OptionsFromCommand(cmd *cli.Command) Options {
 		TemplateSet:   cmd.IsSet(flagTemplate),
 		Git:           !cmd.Bool(flagNoGit),
 		GitSet:        cmd.IsSet(flagNoGit),
+		Description:   cmd.String(flagDescription),
 	}
 }

--- a/cmd/pal/internal/cli/subscommands/init/runner.go
+++ b/cmd/pal/internal/cli/subscommands/init/runner.go
@@ -42,6 +42,7 @@ func (r *runner) Run(ctx context.Context) error {
 			return err
 		}
 	}
+	opts.Description = descriptionOrDefault(opts.Description)
 
 	if opts.Module == "" {
 		return ErrModuleRequired

--- a/cmd/pal/internal/cli/subscommands/init/runner_test.go
+++ b/cmd/pal/internal/cli/subscommands/init/runner_test.go
@@ -181,6 +181,7 @@ func TestOptions_Args(t *testing.T) {
 	require.Equal(t, []string{"example.com/app"}, initcmd.Options{Module: "example.com/app", Git: true}.Args())
 	require.Equal(t, []string{"example.com/app", "-d", "./app"}, initcmd.Options{Module: "example.com/app", Directory: "./app", Git: true}.Args())
 	require.Equal(t, []string{"example.com/app", "--template", "other"}, initcmd.Options{Module: "example.com/app", Template: "other", Git: true}.Args())
+	require.Equal(t, []string{"example.com/app", "--description", "My app"}, initcmd.Options{Module: "example.com/app", Description: "My app", Git: true}.Args())
 }
 
 //nolint:paralleltest // t.Setenv cannot be combined with t.Parallel

--- a/cmd/pal/internal/cli/subscommands/init/wizard_step_description.go
+++ b/cmd/pal/internal/cli/subscommands/init/wizard_step_description.go
@@ -1,0 +1,46 @@
+package initcmd
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/urfave/cli/v3"
+)
+
+const (
+	flagDescription    = "description"
+	defaultDescription = "//TODO: add description"
+)
+
+type wizardStepDescription struct{}
+
+func (wizardStepDescription) Flag() cli.Flag {
+	return &cli.StringFlag{
+		Name:  flagDescription,
+		Usage: "short project description for README and docs (default: " + defaultDescription + ")",
+	}
+}
+
+func (wizardStepDescription) Argument() cli.Argument {
+	return nil
+}
+
+func (wizardStepDescription) Applicable(opts *Options, _ string) bool {
+	return opts.Description == ""
+}
+
+func (wizardStepDescription) Field(opts *Options) (huh.Field, error) {
+	return huh.NewInput().
+		Title("Short project description?").
+		Placeholder(defaultDescription).
+		Value(&opts.Description), nil
+}
+
+func (wizardStepDescription) Abort(_ *Options) bool {
+	return false
+}
+
+func descriptionOrDefault(s string) string {
+	if s == "" {
+		return defaultDescription
+	}
+	return s
+}

--- a/cmd/pal/internal/cli/subscommands/init/wizard_step_template.go
+++ b/cmd/pal/internal/cli/subscommands/init/wizard_step_template.go
@@ -62,9 +62,11 @@ func applyTemplate(dir string, opts Options) error {
 	if name == "" {
 		name = defaultTemplate
 	}
+	desc := descriptionOrDefault(opts.Description)
 	if err := templates.Apply(dir, name, templates.Data{
-		Package: templates.PackageName(opts.Module),
-		Module:  opts.Module,
+		Package:     templates.PackageName(opts.Module),
+		Module:      opts.Module,
+		Description: desc,
 	}); err != nil {
 		return fmt.Errorf("apply template %q: %w", name, err)
 	}

--- a/cmd/pal/internal/cli/subscommands/init/wizard_steps.go
+++ b/cmd/pal/internal/cli/subscommands/init/wizard_steps.go
@@ -29,6 +29,7 @@ type Step interface {
 func Steps() []Step {
 	return []Step{
 		wizardStepModule{},
+		wizardStepDescription{},
 		wizardStepTemplate{},
 		wizardStepGit{},
 	}

--- a/cmd/pal/internal/cli/subscommands/init/wizard_steps_test.go
+++ b/cmd/pal/internal/cli/subscommands/init/wizard_steps_test.go
@@ -14,6 +14,7 @@ const (
 	flagDirectory     = "directory"
 	flagNoGit         = "no-git"
 	flagTemplate      = "template"
+	flagDescription   = "description"
 	argModule         = "module"
 	defaultTemplate   = "cli"
 )
@@ -197,6 +198,46 @@ func TestSteps_TemplateFieldListsEmbeddedTemplates(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, field)
 	require.Equal(t, defaultTemplate, opts.Template)
+}
+
+func TestSteps_DescriptionFlag(t *testing.T) {
+	t.Parallel()
+
+	step := stepByFlag(t, flagDescription)
+	stringFlag, ok := step.Flag().(*cli.StringFlag)
+	require.True(t, ok)
+	require.Equal(t, flagDescription, stringFlag.Name)
+	require.Empty(t, stringFlag.Value)
+	require.Nil(t, step.Argument())
+}
+
+func TestSteps_DescriptionApplicable(t *testing.T) {
+	t.Parallel()
+
+	step := stepByFlag(t, flagDescription)
+	dir := t.TempDir()
+	require.True(t, step.Applicable(&initcmd.Options{}, dir))
+	require.True(t, step.Applicable(&initcmd.Options{Description: ""}, dir))
+	require.False(t, step.Applicable(&initcmd.Options{Description: "x"}, dir))
+}
+
+func TestSteps_DescriptionDoesNotAbort(t *testing.T) {
+	t.Parallel()
+
+	step := stepByFlag(t, flagDescription)
+	require.False(t, step.Abort(&initcmd.Options{}))
+	require.False(t, step.Abort(&initcmd.Options{Description: "x"}))
+}
+
+func TestSteps_DescriptionField(t *testing.T) {
+	t.Parallel()
+
+	step := stepByFlag(t, flagDescription)
+	opts := &initcmd.Options{}
+	field, err := step.Field(opts)
+	require.NoError(t, err)
+	require.NotNil(t, field)
+	require.Empty(t, opts.Description)
 }
 
 func stepByFlag(t *testing.T, name string) initcmd.Step {

--- a/cmd/pal/templates/scaffolds/cli/.github/pull_request_template.md.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/.github/pull_request_template.md.tmpl
@@ -1,0 +1,16 @@
+## Summary
+
+{{.Description}}
+
+Describe what this PR changes and why.
+
+## How To Test
+
+```bash
+task check
+```
+
+## Checklist
+
+- [ ] Tests pass locally (`task check`)
+- [ ] Docs updated when needed

--- a/cmd/pal/templates/scaffolds/cli/.github/workflows/ci.yaml.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/.github/workflows/ci.yaml.tmpl
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v4
+
+      - name: Add asdf plugins
+        run: |
+          asdf plugin add golang || true
+          asdf plugin add golangci-lint || true
+          asdf plugin add task || true
+
+      - name: Install asdf tools
+        run: asdf install
+
+      - name: Check
+        run: task check

--- a/cmd/pal/templates/scaffolds/cli/AGENTS.md.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/AGENTS.md.tmpl
@@ -1,0 +1,38 @@
+# {{.Package}}
+
+{{.Description}}
+
+Module: `{{.Module}}`
+
+## Agent guidelines
+
+Follow these conventions when changing this repository.
+
+### Testing
+
+- Put tests in external `*_test` packages (`package foo_test`), not the same
+  package as production code. For `package main`, use `package main_test`.
+- Prefer [testify](https://github.com/stretchr/testify) assertions
+  (`require` / `assert`) over hand-rolled checks.
+- Prefer `require` when a failed assertion should stop the test immediately;
+  use `assert` when later checks should still run.
+- Name test files `*_test.go` next to the code under test.
+- Prefer table-driven tests when covering multiple similar cases.
+- Use `t.Parallel()` when the test does not share mutable process state
+  (and never combine it with `t.Setenv`).
+
+### Layout
+
+- Application entrypoint: `cmd/{{.Package}}`
+- Shared interfaces: `internal/core`
+- Concrete services: `internal/<name>` with a `Provide()` that returns
+  `pal.Provide[…](…)`
+
+### Commands
+
+```bash
+task check   # lint + test (CI entrypoint)
+task test
+task lint
+task run
+```

--- a/cmd/pal/templates/scaffolds/cli/README.md.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/README.md.tmpl
@@ -1,5 +1,7 @@
 # {{.Package}}
 
+{{.Description}}
+
 CLI application scaffolded with [pal](https://github.com/zhulik/pal), a Go
 dependency-injection and lifecycle toolkit.
 
@@ -27,8 +29,7 @@ task run
 ## Develop
 
 ```bash
-task test
-task lint
+task check
 ```
 
 Coverage HTML report:
@@ -45,6 +46,10 @@ task cover
 ├── internal/
 │   ├── core/              # shared interfaces
 │   └── greeter/           # sample greeter service
+├── .github/
+│   ├── workflows/ci.yaml  # asdf + task check
+│   └── pull_request_template.md
+├── AGENTS.md              # agent / contributor conventions
 ├── Taskfile.yaml          # test, lint, run
 ├── .golangci.yaml         # linter config
 └── .gitignore

--- a/cmd/pal/templates/scaffolds/cli/Taskfile.yaml.tmpl
+++ b/cmd/pal/templates/scaffolds/cli/Taskfile.yaml.tmpl
@@ -7,6 +7,12 @@ tasks:
       - task: lint
       - task: test
 
+  check:
+    desc: Lint and test (CI entrypoint)
+    deps:
+      - lint
+      - test
+
   test:
     desc: Run tests
     cmds:

--- a/cmd/pal/templates/templates.go
+++ b/cmd/pal/templates/templates.go
@@ -34,6 +34,9 @@ type Data struct {
 	Package string
 	// Module is the full Go module path (e.g. github.com/user/app).
 	Module string
+	// Description is a short project description for README, AGENTS.md, and
+	// other docs.
+	Description string
 }
 
 // Exists reports whether name is a known project template directory under FS.

--- a/cmd/pal/templates/templates_test.go
+++ b/cmd/pal/templates/templates_test.go
@@ -47,8 +47,9 @@ func TestApplyCLI(t *testing.T) {
 
 	dir := t.TempDir()
 	err := templates.Apply(dir, "cli", templates.Data{
-		Package: "myapp",
-		Module:  "example.com/myapp",
+		Package:     "myapp",
+		Module:      "example.com/myapp",
+		Description: "A sample CLI app.",
 	})
 	require.NoError(t, err)
 
@@ -70,10 +71,13 @@ func TestApplyCLI(t *testing.T) {
 
 	for _, rel := range []string{
 		"README.md",
+		"AGENTS.md",
 		".gitignore",
 		"Taskfile.yaml",
 		".golangci.yaml",
 		".tool-versions",
+		".github/workflows/ci.yaml",
+		".github/pull_request_template.md",
 		"internal/core/interfaces.go",
 		"internal/greeter/greeter.go",
 		"internal/greeter/services.go",
@@ -99,13 +103,35 @@ func TestApplyCLI(t *testing.T) {
 	readme, err := os.ReadFile(filepath.Join(dir, "README.md"))
 	require.NoError(t, err)
 	require.Contains(t, string(readme), "# myapp")
+	require.Contains(t, string(readme), "A sample CLI app.")
 	require.Contains(t, string(readme), "example.com/myapp")
 	require.Contains(t, string(readme), "go run ./cmd/myapp")
 	require.NotContains(t, string(readme), "{{.")
 
+	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(agents), "# myapp")
+	require.Contains(t, string(agents), "A sample CLI app.")
+	require.Contains(t, string(agents), "package foo_test")
+	require.Contains(t, string(agents), "testify")
+	require.NotContains(t, string(agents), "{{.")
+
+	prTemplate, err := os.ReadFile(filepath.Join(dir, ".github", "pull_request_template.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(prTemplate), "A sample CLI app.")
+	require.Contains(t, string(prTemplate), "task check")
+	require.NotContains(t, string(prTemplate), "{{.")
+
+	ci, err := os.ReadFile(filepath.Join(dir, ".github", "workflows", "ci.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(ci), "asdf-vm/actions/setup")
+	require.Contains(t, string(ci), "asdf install")
+	require.Contains(t, string(ci), "task check")
+
 	taskfile, err := os.ReadFile(filepath.Join(dir, "Taskfile.yaml"))
 	require.NoError(t, err)
 	require.Contains(t, string(taskfile), "go run ./cmd/myapp")
+	require.Contains(t, string(taskfile), "check:")
 	require.NotContains(t, string(taskfile), "{{.")
 }
 
@@ -133,8 +159,9 @@ func TestCLIScaffoldREADMEGoVersion(t *testing.T) {
 
 	dir := t.TempDir()
 	require.NoError(t, templates.Apply(dir, "cli", templates.Data{
-		Package: "myapp",
-		Module:  "example.com/myapp",
+		Package:     "myapp",
+		Module:      "example.com/myapp",
+		Description: "A sample CLI app.",
 	}))
 	readme, err := os.ReadFile(filepath.Join(dir, "README.md"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Enrich the `cli` scaffold with CI, PR, and agent docs, and add an init `--description` step so generated docs get a real project blurb.

## Changes

- Add scaffold `AGENTS.md`, GitHub PR template, asdf-based CI workflow, and a `check` Taskfile target
- Add `templates.Data.Description` for README / AGENTS / PR template rendering
- Add init `--description` wizard/CLI step (empty → `//TODO: add description`; non-empty skips the prompt)

## How To Test

```bash
task -d cmd/pal lint-fix
task -d cmd/pal test
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact
