### PR TITLE
refactor!: make ServiceDef registration-only

### DIFF
--- a/container.go
+++ b/container.go
@@ -82,7 +82,11 @@ func (c *Container) Init(ctx context.Context) error {
 	}
 
 	for _, service := range c.graph.ReverseTopologicalOrder() {
-		if err := service.Init(ctx); err != nil {
+		initer, ok := service.(serviceIniter)
+		if !ok {
+			continue
+		}
+		if err := initer.Init(ctx); err != nil {
 			c.logger.Error("Failed to initialize container", "error", err)
 			return err
 		}
@@ -222,8 +226,11 @@ func (c *Container) Shutdown(ctx context.Context) error {
 	c.logger.Debug("Shutting down all runners")
 
 	for _, service := range c.graph.TopologicalOrder() {
-		err := service.Shutdown(ctx)
-		if err != nil {
+		shutdowner, ok := service.(serviceShutdowner)
+		if !ok {
+			continue
+		}
+		if err := shutdowner.Shutdown(ctx); err != nil {
 			c.logger.Error("Failed to shutdown service. Exiting immediately", "service", service.Name(), "error", err)
 			return err
 		}
@@ -245,12 +252,12 @@ func (c *Container) HealthCheck(ctx context.Context) error {
 				return nil
 			}
 
-			err := service.HealthCheck(ctx)
-			if err != nil {
-				return err
+			healthChecker, ok := service.(serviceHealthChecker)
+			if !ok {
+				return nil
 			}
 
-			return nil
+			return healthChecker.HealthCheck(ctx)
 		})
 	}
 

--- a/container_test.go
+++ b/container_test.go
@@ -10,14 +10,35 @@ import (
 )
 
 func NewMockService(t *testing.T, name string) *MockServiceDef {
+	t.Helper()
 	mock := NewMockServiceDef(t)
 
 	mock.EXPECT().Name().Return(name).Maybe()
 	mock.EXPECT().Dependencies().Return(nil).Maybe()
 	mock.EXPECT().Make().Return(nil).Maybe()
 	mock.EXPECT().Arguments().Return(0).Maybe()
+	mock.EXPECT().ShouldWaitForRunner().Return(nil).Maybe()
 
 	return mock
+}
+
+// mockLifecycleService is a ServiceDef that also drives Init/Shutdown/HealthCheck on the definition,
+// matching Provide* wrappers after lifecycle was removed from ServiceDef itself.
+type mockLifecycleService struct {
+	*MockServiceDef
+	*MockIniter
+	*MockShutdowner
+	*MockHealthChecker
+}
+
+func NewMockLifecycleService(t *testing.T, name string) *mockLifecycleService {
+	t.Helper()
+	return &mockLifecycleService{
+		MockServiceDef:    NewMockService(t, name),
+		MockIniter:        NewMockIniter(t),
+		MockShutdowner:    NewMockShutdowner(t),
+		MockHealthChecker: NewMockHealthChecker(t),
+	}
 }
 
 type cycleServiceA struct {
@@ -63,16 +84,31 @@ func TestContainer_New(t *testing.T) {
 func TestContainer_Init(t *testing.T) {
 	t.Parallel()
 
-	t.Run("initializes singleton services successfully", func(t *testing.T) {
+	t.Run("skips services without Init on the definition", func(t *testing.T) {
 		t.Parallel()
 
-		service1 := NewMockService(t, "service1")
-		service2 := NewMockService(t, "service2")
-		service3 := NewMockService(t, "service3")
+		c := pal.NewContainer(
+			&pal.Pal{},
+			NewMockService(t, "service1"),
+			NewMockService(t, "service2"),
+			NewMockService(t, "service3"),
+		)
 
-		service1.EXPECT().Init(t.Context()).Return(nil)
-		service2.EXPECT().Init(t.Context()).Return(nil)
-		service3.EXPECT().Init(t.Context()).Return(nil)
+		err := c.Init(t.Context())
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("initializes services that implement Init on the definition", func(t *testing.T) {
+		t.Parallel()
+
+		service1 := NewMockLifecycleService(t, "service1")
+		service2 := NewMockLifecycleService(t, "service2")
+		service3 := NewMockLifecycleService(t, "service3")
+
+		service1.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service2.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service3.MockIniter.EXPECT().Init(t.Context()).Return(nil)
 
 		c := pal.NewContainer(&pal.Pal{}, service1, service2, service3)
 
@@ -84,11 +120,11 @@ func TestContainer_Init(t *testing.T) {
 	t.Run("returns error when service initialization fails", func(t *testing.T) {
 		t.Parallel()
 
-		service1 := NewMockService(t, "service1")
-		service2 := NewMockService(t, "service2")
+		service1 := NewMockLifecycleService(t, "service1")
+		service2 := NewMockLifecycleService(t, "service2")
 
-		service1.EXPECT().Init(t.Context()).Return(nil).Maybe() // Init order is not guaranteed
-		service2.EXPECT().Init(t.Context()).Return(errTest).Once()
+		service1.MockIniter.EXPECT().Init(t.Context()).Return(nil).Maybe() // Init order is not guaranteed
+		service2.MockIniter.EXPECT().Init(t.Context()).Return(errTest).Once()
 
 		c := pal.NewContainer(&pal.Pal{}, service1, service2)
 
@@ -126,7 +162,6 @@ func TestContainer_Invoke(t *testing.T) {
 		expectedInstance := struct{}{}
 
 		service := NewMockService(t, "service1")
-		service.EXPECT().Init(t.Context()).Return(nil)
 		service.EXPECT().Instance(t.Context()).Return(expectedInstance, nil)
 
 		c := pal.NewContainer(&pal.Pal{}, service)
@@ -152,7 +187,6 @@ func TestContainer_Invoke(t *testing.T) {
 		t.Parallel()
 
 		service := NewMockService(t, "service1")
-		service.EXPECT().Init(t.Context()).Return(nil)
 		service.EXPECT().Instance(t.Context()).Return(nil, errTest)
 
 		c := pal.NewContainer(&pal.Pal{}, service)
@@ -168,20 +202,35 @@ func TestContainer_Invoke(t *testing.T) {
 func TestContainer_Shutdown(t *testing.T) {
 	t.Parallel()
 
-	t.Run("shuts down all singleton services successfully", func(t *testing.T) {
+	t.Run("skips services without Shutdown on the definition", func(t *testing.T) {
 		t.Parallel()
 
-		service1 := NewMockService(t, "service1")
-		service2 := NewMockService(t, "service2")
-		service3 := NewMockService(t, "service3")
+		c := pal.NewContainer(
+			&pal.Pal{},
+			NewMockService(t, "service1"),
+			NewMockService(t, "service2"),
+		)
+		require.NoError(t, c.Init(t.Context()))
 
-		service1.EXPECT().Init(t.Context()).Return(nil)
-		service2.EXPECT().Init(t.Context()).Return(nil)
-		service3.EXPECT().Init(t.Context()).Return(nil)
+		err := c.Shutdown(t.Context())
 
-		service1.EXPECT().Shutdown(t.Context()).Return(nil)
-		service2.EXPECT().Shutdown(t.Context()).Return(nil)
-		service3.EXPECT().Shutdown(t.Context()).Return(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("shuts down services that implement Shutdown on the definition", func(t *testing.T) {
+		t.Parallel()
+
+		service1 := NewMockLifecycleService(t, "service1")
+		service2 := NewMockLifecycleService(t, "service2")
+		service3 := NewMockLifecycleService(t, "service3")
+
+		service1.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service2.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service3.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+
+		service1.MockShutdowner.EXPECT().Shutdown(t.Context()).Return(nil)
+		service2.MockShutdowner.EXPECT().Shutdown(t.Context()).Return(nil)
+		service3.MockShutdowner.EXPECT().Shutdown(t.Context()).Return(nil)
 
 		c := pal.NewContainer(&pal.Pal{}, service1, service2, service3)
 		require.NoError(t, c.Init(t.Context()))
@@ -194,9 +243,9 @@ func TestContainer_Shutdown(t *testing.T) {
 	t.Run("returns error when service shutdown fails", func(t *testing.T) {
 		t.Parallel()
 
-		service := NewMockService(t, "service1")
-		service.EXPECT().Init(t.Context()).Return(nil)
-		service.EXPECT().Shutdown(t.Context()).Return(errTest)
+		service := NewMockLifecycleService(t, "service1")
+		service.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service.MockShutdowner.EXPECT().Shutdown(t.Context()).Return(errTest)
 
 		c := pal.NewContainer(&pal.Pal{}, service)
 		require.NoError(t, c.Init(t.Context()))
@@ -211,20 +260,35 @@ func TestContainer_Shutdown(t *testing.T) {
 func TestContainer_HealthCheck(t *testing.T) {
 	t.Parallel()
 
-	t.Run("health checks all singleton services successfully", func(t *testing.T) {
+	t.Run("skips services without HealthCheck on the definition", func(t *testing.T) {
 		t.Parallel()
 
-		service1 := NewMockService(t, "service1")
-		service2 := NewMockService(t, "service2")
-		service3 := NewMockService(t, "service3")
+		c := pal.NewContainer(
+			&pal.Pal{},
+			NewMockService(t, "service1"),
+			NewMockService(t, "service2"),
+		)
+		require.NoError(t, c.Init(t.Context()))
 
-		service1.EXPECT().Init(t.Context()).Return(nil)
-		service2.EXPECT().Init(t.Context()).Return(nil)
-		service3.EXPECT().Init(t.Context()).Return(nil)
+		err := c.HealthCheck(t.Context())
 
-		service1.EXPECT().HealthCheck(t.Context()).Return(nil)
-		service2.EXPECT().HealthCheck(t.Context()).Return(nil)
-		service3.EXPECT().HealthCheck(t.Context()).Return(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("health checks services that implement HealthCheck on the definition", func(t *testing.T) {
+		t.Parallel()
+
+		service1 := NewMockLifecycleService(t, "service1")
+		service2 := NewMockLifecycleService(t, "service2")
+		service3 := NewMockLifecycleService(t, "service3")
+
+		service1.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service2.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service3.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+
+		service1.MockHealthChecker.EXPECT().HealthCheck(t.Context()).Return(nil)
+		service2.MockHealthChecker.EXPECT().HealthCheck(t.Context()).Return(nil)
+		service3.MockHealthChecker.EXPECT().HealthCheck(t.Context()).Return(nil)
 
 		c := pal.NewContainer(&pal.Pal{}, service1, service2, service3)
 		require.NoError(t, c.Init(t.Context()))
@@ -237,9 +301,9 @@ func TestContainer_HealthCheck(t *testing.T) {
 	t.Run("returns error when service health check fails", func(t *testing.T) {
 		t.Parallel()
 
-		service := NewMockService(t, "service1")
-		service.EXPECT().Init(t.Context()).Return(nil)
-		service.EXPECT().HealthCheck(t.Context()).Return(errTest)
+		service := NewMockLifecycleService(t, "service1")
+		service.MockIniter.EXPECT().Init(t.Context()).Return(nil)
+		service.MockHealthChecker.EXPECT().HealthCheck(t.Context()).Return(errTest)
 
 		c := pal.NewContainer(&pal.Pal{}, service)
 		require.NoError(t, c.Init(t.Context()))
@@ -259,9 +323,6 @@ func TestContainer_Services(t *testing.T) {
 
 		service1 := NewMockService(t, "service1")
 		service2 := NewMockService(t, "service2")
-
-		service1.EXPECT().Init(t.Context()).Return(nil)
-		service2.EXPECT().Init(t.Context()).Return(nil)
 
 		c := pal.NewContainer(&pal.Pal{}, service1, service2)
 		require.NoError(t, c.Init(t.Context()))
@@ -283,3 +344,5 @@ func TestContainer_Services(t *testing.T) {
 		assert.Empty(t, result)
 	})
 }
+
+var _ pal.ServiceDef = (*mockLifecycleService)(nil)

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,16 +21,16 @@ type PalRunConfiger interface { //nolint:revive
 	PalShouldWaitForRunner() bool
 }
 
-// ServiceDef is a definition of a service. In the case of a singleton service, it also holds the instance.
-// This interface embeds the standard lifecycle interfaces ([Initer], [HealthChecker], [Shutdowner], [Runner]);
-// concrete services may instead implement the Pal-prefixed alternatives ([PalIniter], [PalHealthChecker], [PalShutdowner], [PalRunner], [PalRunConfiger]) where method names would otherwise clash.
-// It adds methods specific to service definition and management.
+// ServiceDef is a registration and provisioning contract for a service.
+// In the case of a singleton service, the definition also holds the instance.
+//
+// Lifecycle (Init, Run, Shutdown, HealthCheck) is not part of this interface.
+// Pal discovers it on the service instance — via [Initer], [HealthChecker], [Shutdowner], [Runner]
+// or the Pal-prefixed alternatives ([PalIniter], [PalHealthChecker], [PalShutdowner], [PalRunner], [PalRunConfiger]) —
+// and on Provide* wrappers that forward to those instance methods and optional hooks.
+// Custom ServiceDef implementers only need the methods below; implement
+// Init/Run/Shutdown/HealthCheck on the definition only when the wrapper itself drives lifecycle.
 type ServiceDef interface {
-	Initer
-	HealthChecker
-	Shutdowner
-	Runner
-
 	// ShouldWaitForRunner reports runner scheduling for this service definition.
 	// nil means the service is not a runner; otherwise true = main runner and false = secondary.
 	// Wrappers default to true when the instance implements Runner/PalRunner but not
@@ -58,6 +58,23 @@ type ServiceDef interface {
 	// Dependencies allows services to provide their own dependencies.
 	Dependencies() []ServiceDef
 }
+
+// Optional lifecycle methods a ServiceDef wrapper may implement to drive Init/Run/Shutdown/HealthCheck.
+// Container and RunServices type-assert these; they are not part of [ServiceDef].
+type (
+	serviceIniter interface {
+		Init(ctx context.Context) error
+	}
+	serviceHealthChecker interface {
+		HealthCheck(ctx context.Context) error
+	}
+	serviceShutdowner interface {
+		Shutdown(ctx context.Context) error
+	}
+	serviceRunner interface {
+		Run(ctx context.Context) error
+	}
+)
 
 // Invoker is an interface for retrieving services from a container and injecting them into structs.
 // Both Container and Pal implement this interface, allowing services to be retrieved from either.

--- a/runners.go
+++ b/runners.go
@@ -29,7 +29,11 @@ func RunServices(ctx context.Context, services []ServiceDef) error {
 
 	runService := func(service ServiceDef) func() error {
 		return func() error {
-			err := service.Run(ctx)
+			runner, ok := service.(serviceRunner)
+			if !ok {
+				return nil
+			}
+			err := runner.Run(ctx)
 			if errors.Is(err, context.Canceled) {
 				return nil
 			}

--- a/service_typed.go
+++ b/service_typed.go
@@ -1,35 +1,11 @@
 package pal
 
-import (
-	"context"
-)
-
 type ServiceTyped[T any] struct {
 	P    *Pal
 	name string
 }
 
 func (c *ServiceTyped[T]) Dependencies() []ServiceDef {
-	return nil
-}
-
-// Run is a no-op for factory services as they don't run in the background.
-func (c *ServiceTyped[T]) Run(_ context.Context) error {
-	return nil
-}
-
-// Init is a no-op for factory services as they are created on demand.
-func (c *ServiceTyped[T]) Init(_ context.Context) error {
-	return nil
-}
-
-// HealthCheck is a no-op for factory services as they are created on demand.
-func (c *ServiceTyped[T]) HealthCheck(_ context.Context) error {
-	return nil
-}
-
-// Shutdown is a no-op for factory services as they are created on demand.
-func (c *ServiceTyped[T]) Shutdown(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

**Breaking change:** `ServiceDef` is registration-only. It no longer embeds `Initer`, `HealthChecker`, `Shutdowner`, or `Runner`. Lifecycle stays on service **instances** (and Provide* wrappers that forward to them); `Container` / `RunServices` discover wrapper lifecycle via optional type assertions.

## Changes

- `ServiceDef` methods: `Name`, `Make`, `Instance`, `Arguments`, `Dependencies`, `ShouldWaitForRunner` only
- Removed no-op `Init` / `Run` / `Shutdown` / `HealthCheck` from `ServiceTyped`
- `Container` and `RunServices` call lifecycle only when the definition implements the corresponding optional methods
- Tests updated for the new contract

## Migration guide

**Typical apps using `Provide` / `ProvideFn` / `ProvideRunner` / factories:** no change. Instance lifecycle interfaces and hooks behave as before.

**Custom `ServiceDef` implementers:** drop no-op lifecycle methods unless the definition itself drives lifecycle (like built-in wrappers). Lifecycle belongs on the instance:

```go
// Before — custom ServiceDef had to satisfy embedded Initer/Runner/etc.
func (d *MyDef) Init(context.Context) error          { return nil }
func (d *MyDef) Run(context.Context) error           { return nil }
func (d *MyDef) Shutdown(context.Context) error      { return nil }
func (d *MyDef) HealthCheck(context.Context) error   { return nil }

// After — registration methods only; implement Init/Run/… on the instance (or on the def only if you drive lifecycle yourself)
```

If you previously called `service.Init` / `.Run` / `.Shutdown` / `.HealthCheck` through a `ServiceDef` value, type-assert first (or call through a concrete wrapper type).

## How To Test

```bash
task lint-fix
task test
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact
