### PR TITLE
refactor!: make Provide* return Hookable and take Invoker in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ a few rules described below.
     rather than conflict.
 
 - Testability:
-  - Pal provides tools to simplify testing, such as the ability to register mock services using ProvideConst.
+  - Pal provides tools to simplify testing, such as the ability to register mock services using Provide.
   - The container design allows for easy swapping of real implementations with test doubles.
   - Services can be tested in isolation by creating a test container with only the necessary dependencies.
 
@@ -76,7 +76,7 @@ a few rules described below.
 - [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection) — specific implementation of the Inversion
   of Control pattern where objects receive their dependencies through constructor arguments, method calls, or property
   setters rather than creating them themselves.
-- Container — a registry of services within the app. It is responsible for managing service lifecycle.
+- Container — a registry of services within the app (used internally by Pal; also available for advanced use).
 - Service — is an interface that defines a set of methods or operations. Concrete implementations of these services are
   responsible for providing specific functionalities within the application. Services can perform tasks on their own or
   can be used by other services. Pal recognizes a few types of services:
@@ -102,13 +102,14 @@ a few rules described below.
 
 ## API Functions
 
-Pal provides several functions for registering services:
+Pal provides several functions for registering services. They return interfaces (`Hookable` or `ServiceDef`) so the default path stays implementation-agnostic:
 
-- `Provide[T any](value T)` - Registers an instance of service.
-- `ProvideFn[T any](fn func(ctx context.Context) (T, error))` - Registers a singleton service created using the provided function.
-- `ProvideFactory{0-5}[I any, T any, {0-5}P any](fn func(ctx context.Context, {0-5}P args) (T, error)))` - Registers a factory service created using the provided function with given amount of arguments.
-- `ProvideList(...ServiceDef)` - Registers multiple services at once, useful when splitting apps into modules, see [example](./examples/web)
-- There are also `Named` versions of `Provide` functions, they can be used along with `name` tag and `Named` versions `Invoke` functions if you want to give your services explicit names.
+- `Provide[T any](value T) Hookable[T]` - Registers an instance of a service; chain `ToInit` / `ToShutdown` / `ToHealthCheck` as needed.
+- `ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) Hookable[T]` - Registers a singleton built with the provided function.
+- `ProvideFactory{0-5}[...](...) ServiceDef` - Registers a factory service created with the provided function (0–5 args).
+- `ProvideRunner(fn) ServiceDef` - Registers an anonymous background runner.
+- `ProvideList(...ServiceDef) ServiceDef` - Registers multiple services at once, useful when splitting apps into modules, see [example](./examples/web)
+- There are also `Named` versions of `Provide` functions, they can be used along with `name` tag and `Named` versions of `Invoke` functions if you want to give your services explicit names.
 
 Pal also provides functions for retrieving services:
 
@@ -122,8 +123,7 @@ Pal also provides functions for retrieving services:
 - There are `Named` versions of `Invoke` functions that allow retrieving services by their explicit names.
 
 All these functions accept nil as invoker, in this case, a Pal instance will be extracted from the context.
-Pal automatically adds itself into contexts passed to `Init`, `Shutdown`, and `Run` under the `pal.CtxValue` key.
-You can extract it manually with `pal.FromContext`
+Pal automatically stores itself in contexts passed to `Init`, `Shutdown`, and `Run`. Use `pal.FromContext` / `pal.WithPal` to read or write it.
 
 ## Service Types
 
@@ -146,7 +146,7 @@ Singleton services are created once during application initialization and reused
 pal.Provide[MyService](&MyServiceImpl{})
 
 // Register a singleton service using a factory function
-pal.ProvideFn[MyService](func(ctx context.Context) (MyServiceImpl, error) {
+pal.ProvideFn[MyService](func(ctx context.Context) (*MyServiceImpl, error) {
     return &MyServiceImpl{}, nil
 })
 ```
@@ -214,9 +214,9 @@ Const services wrap existing instances. They are useful for:
 **Registration:**
 
 ```go
-// Register a const service
+// Register an existing instance
 existingInstance := &MyServiceImpl{}
-pal.ProvideConst[MyService](existingInstance)
+pal.Provide[MyService](existingInstance)
 ```
 
 ### Runner Services
@@ -272,27 +272,30 @@ lifecycle management code closer to the resources it manages.
 Hooks can be used with any service type and provide a flexible way to add lifecycle behavior:
 
 ```go
-// With const services
-pal.ProvideConst[MyService](existingInstance).
-    ToInit(func(ctx context.Context, service MyService, pal *pal.Pal) error {
+// With Provide (const / instance services)
+pal.Provide[MyService](existingInstance).
+    ToInit(func(ctx context.Context, service MyService, invoker pal.Invoker) error {
         // Custom initialization logic
         return service.Connect()
     }).
-    ToShutdown(func(ctx context.Context, service MyService, pal *pal.Pal) error {
+    ToShutdown(func(ctx context.Context, service MyService, invoker pal.Invoker) error {
         // Custom shutdown logic
         return service.Disconnect()
     }).
-    ToHealthCheck(func(ctx context.Context, service MyService, pal *pal.Pal) error {
+    ToHealthCheck(func(ctx context.Context, service MyService, invoker pal.Invoker) error {
         // Custom health check logic
         return service.Ping()
     })
 
-// With function-based services
+// With ProvideFn
 pal.ProvideFn[MyService](func(ctx context.Context) (*MyServiceImpl, error) {
     return &MyServiceImpl{}, nil
 }).
-    ToInit(func(ctx context.Context, service MyService, pal *pal.Pal) error {
+    ToInit(func(ctx context.Context, service *MyServiceImpl, invoker pal.Invoker) error {
         return service.Initialize()
+    }).
+    ToShutdown(func(ctx context.Context, service *MyServiceImpl, invoker pal.Invoker) error {
+        return service.Disconnect()
     })
 ```
 
@@ -302,6 +305,17 @@ Examples can be found here:
 
 - [example_container_test.go](./example_container_test.go)
 - [example_pal_test.go](./example_pal_test.go)
+
+## Advanced / hackable API
+
+The default path is `Provide*` → `New` → `Run` / `Invoke*`. For power users, these remain exported and may change more freely than the primary API:
+
+- Concrete wrappers: `ServiceConst`, `ServiceFnSingleton`, `ServiceFactory0`–`5`, `ServiceRunner`, `ServiceList`, `ServiceTyped`
+- `Container`, `NewContainer`, `Pal.Container()`, `Pal.Services()`, `RunServices`
+- Dependency graph: `Pal.TreeJSON()`, `GraphToJSON`, [`pkg/dag`](./pkg/dag)
+- Inspect helpers that take a raw DAG (`inspect.DAGToJSON`)
+
+Prefer the interface returns from `Provide*` unless you need to type-assert or construct these types deliberately.
 
 ## Example apps
 
@@ -398,7 +412,7 @@ To get the most out of Pal, follow these best practices:
    - Design services as small, focused components with a single responsibility.
    - Use interfaces to define service contracts, especially for services that might have multiple implementations.
    - Implement the optional lifecycle interfaces ([Initer](./lifecycle_interfaces.go#L39), [Shutdowner](./lifecycle_interfaces.go#L20), [HealthChecker](./lifecycle_interfaces.go#L5), or the [Pal-prefixed](./lifecycle_interfaces.go#L66) alternatives when names clash) when appropriate.
-   - Use `ProvideConst` and `ProvideFn*` functions with `ToShutdown` hook to register services without dedicated
+   - Use `Provide` and `ProvideFn` with `ToShutdown` hooks to register services without dedicated
      interfaces and struct wrappers.
 
 2. **Dependency Management**:
@@ -413,7 +427,7 @@ To get the most out of Pal, follow these best practices:
 
 4. **Testing**:
    - Create mock implementations of your service interfaces for testing.
-   - Use `ProvideConst` to register mock services in your tests.
+   - Use `Provide` to register mock services in your tests.
    - Test each service in isolation before testing them together.
 
 5. **Application Structure**:

--- a/api.go
+++ b/api.go
@@ -13,27 +13,27 @@ import (
 // - An interface, in this case passed value must implement it. Used when T may have multiple implementations like mocks for tests.
 // - A pointer to an instance of `T`. For instance,`Provide[*Foo](&Foo{})`. Used when mocking is not required.
 // If the passed value implements [Initer] or [PalIniter], the matching init method is called after dependency injection,
-// unless a ToInit hook is set on the returned [ServiceConst] (see [ServiceConst.ToInit]).
-func Provide[T any](value T) *ServiceConst[T] {
+// unless a ToInit hook is set on the returned [Hookable] (see [Hookable.ToInit]).
+func Provide[T any](value T) Hookable[T] {
 	validateNonNilPointer(value)
 
 	return ProvideNamed(typetostring.GetType[T](), value)
 }
 
 // ProvideNamed registers a const as a service with a given name. Acts like Provide but allows to specify a name.
-func ProvideNamed[T any](name string, value T) *ServiceConst[T] {
+func ProvideNamed[T any](name string, value T) Hookable[T] {
 	validateNonNilPointer(value)
 
 	return &ServiceConst[T]{instance: value, ServiceTyped: ServiceTyped[T]{name: name}}
 }
 
 // ProvideFn registers a singleton built with a given function.
-func ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) *ServiceFnSingleton[I, T] {
+func ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) Hookable[T] {
 	return ProvideNamedFn[I](typetostring.GetType[I](), fn)
 }
 
-// ProvideFn registers a singleton built with a given function.
-func ProvideNamedFn[I any, T any](name string, fn func(ctx context.Context) (T, error)) *ServiceFnSingleton[I, T] {
+// ProvideNamedFn registers a singleton built with a given function under a custom name.
+func ProvideNamedFn[I any, T any](name string, fn func(ctx context.Context) (T, error)) Hookable[T] {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFnSingleton[I, T]{
@@ -44,50 +44,50 @@ func ProvideNamedFn[I any, T any](name string, fn func(ctx context.Context) (T, 
 
 // ProvideRunner turns the given function into an anounumous runner. It will run in the background, and the passed context will
 // be canceled on app shutdown.
-func ProvideRunner(fn func(ctx context.Context) error) *ServiceRunner {
+func ProvideRunner(fn func(ctx context.Context) error) ServiceDef {
 	return &ServiceRunner{
 		fn: fn,
 	}
 }
 
 // ProvideList registers a list of given services.
-func ProvideList(services ...ServiceDef) *ServiceList {
+func ProvideList(services ...ServiceDef) ServiceDef {
 	return &ServiceList{Services: services}
 }
 
 // ProvideFactory0 registers a factory service that is build with a given function with no arguments.
-func ProvideFactory0[I any, T any](fn func(ctx context.Context) (T, error)) *ServiceFactory0[I, T] {
+func ProvideFactory0[I any, T any](fn func(ctx context.Context) (T, error)) ServiceDef {
 	return ProvideNamedFactory0[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideFactory1 registers a factory service that is built in runtime with a given function that takes one argument.
-func ProvideFactory1[I any, T any, P1 any](fn func(ctx context.Context, p1 P1) (T, error)) *ServiceFactory1[I, T, P1] {
+func ProvideFactory1[I any, T any, P1 any](fn func(ctx context.Context, p1 P1) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 	return ProvideNamedFactory1[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideFactory2 registers a factory service that is built in runtime with a given function that takes two arguments.
-func ProvideFactory2[I any, T any, P1 any, P2 any](fn func(ctx context.Context, p1 P1, p2 P2) (T, error)) *ServiceFactory2[I, T, P1, P2] {
+func ProvideFactory2[I any, T any, P1 any, P2 any](fn func(ctx context.Context, p1 P1, p2 P2) (T, error)) ServiceDef {
 	return ProvideNamedFactory2[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideFactory3 registers a factory service that is built in runtime with a given function that takes three arguments.
-func ProvideFactory3[I any, T any, P1 any, P2 any, P3 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3) (T, error)) *ServiceFactory3[I, T, P1, P2, P3] {
+func ProvideFactory3[I any, T any, P1 any, P2 any, P3 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3) (T, error)) ServiceDef {
 	return ProvideNamedFactory3[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideFactory4 registers a factory service that is built in runtime with a given function that takes four arguments.
-func ProvideFactory4[I any, T any, P1 any, P2 any, P3 any, P4 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4) (T, error)) *ServiceFactory4[I, T, P1, P2, P3, P4] {
+func ProvideFactory4[I any, T any, P1 any, P2 any, P3 any, P4 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4) (T, error)) ServiceDef {
 	return ProvideNamedFactory4[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideFactory5 registers a factory service that is built in runtime with a given function that takes five arguments.
-func ProvideFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4, p5 P5) (T, error)) *ServiceFactory5[I, T, P1, P2, P3, P4, P5] {
+func ProvideFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4, p5 P5) (T, error)) ServiceDef {
 	return ProvideNamedFactory5[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideNamedFactory0 is like ProvideFactory0 but allows to specify a name.
-func ProvideNamedFactory0[I any, T any](name string, fn func(ctx context.Context) (T, error)) *ServiceFactory0[I, T] {
+func ProvideNamedFactory0[I any, T any](name string, fn func(ctx context.Context) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 	return &ServiceFactory0[I, T]{
 		fn:             fn,
@@ -96,7 +96,7 @@ func ProvideNamedFactory0[I any, T any](name string, fn func(ctx context.Context
 }
 
 // ProvideNamedFactory1 is like ProvideFactory1 but allows to specify a name.
-func ProvideNamedFactory1[I any, T any, P1 any](name string, fn func(ctx context.Context, p1 P1) (T, error)) *ServiceFactory1[I, T, P1] {
+func ProvideNamedFactory1[I any, T any, P1 any](name string, fn func(ctx context.Context, p1 P1) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFactory1[I, T, P1]{
@@ -106,7 +106,7 @@ func ProvideNamedFactory1[I any, T any, P1 any](name string, fn func(ctx context
 }
 
 // ProvideNamedFactory2 is like ProvideFactory2 but allows to specify a name.
-func ProvideNamedFactory2[I any, T any, P1 any, P2 any](name string, fn func(ctx context.Context, p1 P1, p2 P2) (T, error)) *ServiceFactory2[I, T, P1, P2] {
+func ProvideNamedFactory2[I any, T any, P1 any, P2 any](name string, fn func(ctx context.Context, p1 P1, p2 P2) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFactory2[I, T, P1, P2]{
@@ -116,7 +116,7 @@ func ProvideNamedFactory2[I any, T any, P1 any, P2 any](name string, fn func(ctx
 }
 
 // ProvideNamedFactory3 is like ProvideFactory3 but allows to specify a name.
-func ProvideNamedFactory3[I any, T any, P1 any, P2 any, P3 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3) (T, error)) *ServiceFactory3[I, T, P1, P2, P3] {
+func ProvideNamedFactory3[I any, T any, P1 any, P2 any, P3 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFactory3[I, T, P1, P2, P3]{
@@ -126,7 +126,7 @@ func ProvideNamedFactory3[I any, T any, P1 any, P2 any, P3 any](name string, fn 
 }
 
 // ProvideNamedFactory4 is like ProvideFactory4 but allows to specify a name.
-func ProvideNamedFactory4[I any, T any, P1 any, P2 any, P3 any, P4 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4) (T, error)) *ServiceFactory4[I, T, P1, P2, P3, P4] {
+func ProvideNamedFactory4[I any, T any, P1 any, P2 any, P3 any, P4 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFactory4[I, T, P1, P2, P3, P4]{
@@ -136,7 +136,7 @@ func ProvideNamedFactory4[I any, T any, P1 any, P2 any, P3 any, P4 any](name str
 }
 
 // ProvideNamedFactory5 is like ProvideFactory5 but allows to specify a name.
-func ProvideNamedFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4, p5 P5) (T, error)) *ServiceFactory5[I, T, P1, P2, P3, P4, P5] {
+func ProvideNamedFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](name string, fn func(ctx context.Context, p1 P1, p2 P2, p3 P3, p4 P4, p5 P5) (T, error)) ServiceDef {
 	validateFactoryFunction[I, T](fn)
 
 	return &ServiceFactory5[I, T, P1, P2, P3, P4, P5]{
@@ -146,7 +146,7 @@ func ProvideNamedFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](
 }
 
 // ProvidePal registers all services for the given pal instance
-func ProvidePal(pal *Pal) *ServiceList {
+func ProvidePal(pal *Pal) ServiceDef {
 	services := make([]ServiceDef, 0, len(pal.Services()))
 	for _, v := range pal.Services() {
 		if v.Name() != "*github.com/zhulik/pal.Pal" {

--- a/api_test.go
+++ b/api_test.go
@@ -30,7 +30,7 @@ func TestProvide(t *testing.T) {
 		t.Parallel()
 
 		service := pal.Provide(NewMockRunnerServiceStruct(t)).
-			ToInit(func(ctx context.Context, service *RunnerServiceStruct, _ *pal.Pal) error {
+			ToInit(func(ctx context.Context, service *RunnerServiceStruct, _ pal.Invoker) error {
 				service.MockRunner.EXPECT().Run(ctx).Return(nil)
 
 				return nil

--- a/container.go
+++ b/container.go
@@ -26,7 +26,10 @@ type factoryService interface {
 	MustFactory() any
 }
 
-// Container is responsible for storing services, instances and the dependency graph
+// Container is responsible for storing services, instances and the dependency graph.
+//
+// Advanced: prefer [Pal] for normal apps; Container remains exported for power users
+// (custom lifecycles, introspection). May change more freely than Provide/Pal.
 type Container struct {
 	pal *Pal
 
@@ -36,7 +39,9 @@ type Container struct {
 	logger    *slog.Logger
 }
 
-// NewContainer creates a new Container instance
+// NewContainer creates a new Container instance.
+//
+// Advanced: normal apps use [New]; this constructor is for power users.
 func NewContainer(pal *Pal, services ...ServiceDef) *Container {
 	services = flattenServices(services)
 
@@ -147,7 +152,7 @@ func (c *Container) InjectInto(ctx context.Context, target any) error {
 	for i := 0; i < t.NumField(); i++ {
 		field := v.Field(i)
 
-		tags, err := ParseTag(t.Field(i).Tag.Get("pal"))
+		tags, err := parseTag(t.Field(i).Tag.Get("pal"))
 		if err != nil {
 			return err
 		}
@@ -329,7 +334,7 @@ func (c *Container) addDependencyVertex(service ServiceDef, parent ServiceDef) e
 			continue
 		}
 
-		tags, err := ParseTag(field.Tag.Get("pal"))
+		tags, err := parseTag(field.Tag.Get("pal"))
 		if err != nil {
 			return err
 		}

--- a/example_container_test.go
+++ b/example_container_test.go
@@ -21,7 +21,8 @@ func (s *SimpleServiceImpl) GetMessage() string {
 	return "Hello from SimpleService"
 }
 
-// This example demonstrates how to create a Pal instance with services and use it.
+// Example_container demonstrates creating a Pal instance with services and using it.
+// (Named for historical reasons; apps go through Pal, not a public Container constructor.)
 func Example_container() {
 	// Create a Pal instance with the service
 	p := pal.New(

--- a/examples/hooks/pinger/services.go
+++ b/examples/hooks/pinger/services.go
@@ -12,7 +12,7 @@ import (
 func Provide() pal.ServiceDef {
 	return pal.ProvideList(
 		pal.Provide(&Pinger{}).
-			ToInit(func(_ context.Context, pinger *Pinger, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, pinger *Pinger, _ pal.Invoker) error {
 				defer pinger.Logger.Info("Pinger initialized")
 
 				pinger.client = &http.Client{
@@ -21,7 +21,7 @@ func Provide() pal.ServiceDef {
 
 				return nil
 			}).
-			ToShutdown(func(_ context.Context, pinger *Pinger, _ *pal.Pal) error {
+			ToShutdown(func(_ context.Context, pinger *Pinger, _ pal.Invoker) error {
 				defer pinger.Logger.Info("Pinger shut down")
 				pinger.client.CloseIdleConnections()
 

--- a/examples/hooks/server/services.go
+++ b/examples/hooks/server/services.go
@@ -10,7 +10,7 @@ import (
 // Provide provides the server service.
 func Provide() pal.ServiceDef {
 	return pal.ProvideList(
-		pal.Provide(&Server{}).ToInit(func(_ context.Context, server *Server, _ *pal.Pal) error {
+		pal.Provide(&Server{}).ToInit(func(_ context.Context, server *Server, _ pal.Invoker) error {
 			defer server.Logger.Info("Server initialized")
 
 			server.server = &http.Server{ //nolint:gosec

--- a/hook_priority_test.go
+++ b/hook_priority_test.go
@@ -52,7 +52,7 @@ func TestHookPriority_ToInit(t *testing.T) {
 
 		hookCalled := false
 		palService := pal.Provide(service).
-			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				hookCalled = true
 				return nil
 			})
@@ -76,7 +76,7 @@ func TestHookPriority_ToInit(t *testing.T) {
 		service := &HookPriorityTestService{}
 
 		palService := pal.Provide(service).
-			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				return expectedErr
 			})
 
@@ -113,7 +113,7 @@ func TestHookPriority_ToHealthCheck(t *testing.T) {
 
 		hookCalled := false
 		palService := pal.Provide(service).
-			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				hookCalled = true
 				return nil
 			})
@@ -143,7 +143,7 @@ func TestHookPriority_ToHealthCheck(t *testing.T) {
 		service := &HookPriorityTestService{}
 
 		palService := pal.Provide(service).
-			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				return expectedErr
 			})
 
@@ -190,7 +190,7 @@ func TestHookPriority_ToShutdown(t *testing.T) {
 
 		hookCalled := false
 		palService := pal.Provide(service).
-			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				hookCalled = true
 				return nil
 			})
@@ -218,7 +218,7 @@ func TestHookPriority_ToShutdown(t *testing.T) {
 		service := &HookPriorityTestService{}
 
 		palService := pal.Provide(service).
-			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				return expectedErr
 			})
 
@@ -266,15 +266,15 @@ func TestHookPriority_MultipleHooks(t *testing.T) {
 		shutdownHookCalled := false
 
 		palService := pal.Provide(service).
-			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				initHookCalled = true
 				return nil
 			}).
-			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToHealthCheck(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				healthCheckHookCalled = true
 				return nil
 			}).
-			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ *pal.Pal) error {
+			ToShutdown(func(_ context.Context, _ *HookPriorityTestService, _ pal.Invoker) error {
 				shutdownHookCalled = true
 				return nil
 			})

--- a/inspect/inspect.go
+++ b/inspect/inspect.go
@@ -77,7 +77,7 @@ func (i *Inspect) Run(ctx context.Context) error {
 
 func (i *Inspect) httpTreeJSON(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", jsonContentType)
-	json, err := DAGToJSON(i.P.Container().Graph())
+	json, err := i.P.TreeJSON()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/inspect/tree_json.go
+++ b/inspect/tree_json.go
@@ -1,113 +1,21 @@
 package inspect
 
 import (
-	"encoding/json"
-	"strings"
-
 	"github.com/zhulik/pal"
 	"github.com/zhulik/pal/pkg/dag"
 )
 
-type DAGJSON struct {
-	Nodes []NodeJSON `json:"nodes"`
-	Edges []EdgeJSON `json:"edges"`
-}
+// DAGJSON is an alias of [pal.TreeJSON] kept for compatibility.
+type DAGJSON = pal.TreeJSON
 
-type NodeJSON struct {
-	ID        string `json:"id"`
-	Label     string `json:"label"`
-	InDegree  int    `json:"inDegree"`
-	OutDegree int    `json:"outDegree"`
+// NodeJSON is an alias of [pal.TreeNodeJSON] kept for compatibility.
+type NodeJSON = pal.TreeNodeJSON
 
-	Initer        bool `json:"initer"`
-	Runner        bool `json:"runner"`
-	RunConfiger   bool `json:"runConfiger"`
-	HealthChecker bool `json:"healthChecker"`
-	Shutdowner    bool `json:"shutdowner"`
-}
+// EdgeJSON is an alias of [pal.TreeEdgeJSON] kept for compatibility.
+type EdgeJSON = pal.TreeEdgeJSON
 
-type EdgeJSON struct {
-	From string `json:"from"`
-	To   string `json:"to"`
-}
-
-func serviceToJSON(id string, inDegree int, outDegree int, service pal.ServiceDef) NodeJSON {
-	var initer, runner, runConfiger, healthChecker, shutdowner bool
-
-	if _, ok := service.Make().(pal.PalIniter); ok {
-		initer = true
-	} else if _, ok := service.Make().(pal.Initer); ok {
-		initer = true
-	}
-
-	if _, ok := service.Make().(pal.PalRunner); ok {
-		runner = true
-	} else if _, ok := service.Make().(pal.Runner); ok {
-		runner = true
-	}
-
-	if _, ok := service.Make().(pal.PalRunConfiger); ok {
-		runConfiger = true
-	} else if _, ok := service.Make().(pal.RunConfiger); ok {
-		runConfiger = true
-	}
-
-	if _, ok := service.Make().(pal.PalHealthChecker); ok {
-		healthChecker = true
-	} else if _, ok := service.Make().(pal.HealthChecker); ok {
-		healthChecker = true
-	}
-
-	if _, ok := service.Make().(pal.PalShutdowner); ok {
-		shutdowner = true
-	} else if _, ok := service.Make().(pal.Shutdowner); ok {
-		shutdowner = true
-	}
-
-	idParts := strings.Split(id, "/")
-	label := idParts[len(idParts)-1]
-
-	if strings.HasPrefix(id, "*") {
-		label = "*" + label
-	}
-
-	return NodeJSON{
-		ID:        id,
-		Label:     label,
-		InDegree:  inDegree,
-		OutDegree: outDegree,
-
-		Initer:        initer,
-		Runner:        runner,
-		RunConfiger:   runConfiger,
-		HealthChecker: healthChecker,
-		Shutdowner:    shutdowner,
-	}
-}
-
+// DAGToJSON encodes a dependency DAG as JSON.
+// Advanced: prefer [pal.Pal.TreeJSON] when working from a running Pal instance.
 func DAGToJSON(d *dag.DAG[string, pal.ServiceDef]) ([]byte, error) {
-	var nodes []NodeJSON
-	var edges []EdgeJSON
-
-	// Convert all vertices to NodeJSON
-	for id, service := range d.Vertices() {
-		nodes = append(nodes, serviceToJSON(id, d.GetInDegree(id), len(d.Edges()[id]), service))
-	}
-
-	// Convert all edges to EdgeJSON
-	for from, targets := range d.Edges() {
-		for to := range targets {
-			edges = append(edges, EdgeJSON{
-				From: from,
-				To:   to,
-			})
-		}
-	}
-
-	dagJSON := DAGJSON{
-		Nodes: nodes,
-		Edges: edges,
-	}
-
-	return json.Marshal(dagJSON)
+	return pal.GraphToJSON(d)
 }

--- a/lifecycle_hooks.go
+++ b/lifecycle_hooks.go
@@ -3,13 +3,22 @@ package pal
 import "context"
 
 // LifecycleHook is a function type that can be registered to run at specific points in a service's lifecycle.
-// It receives the service instance, a context, and the Pal instance, and can return an error to indicate failure.
+// It receives the service instance, a context, and an [Invoker] (typically the running [Pal]), and can return an error to indicate failure.
 // These hooks are typically used with ToInit methods to customize service initialization.
-type LifecycleHook[T any] func(ctx context.Context, service T, pal *Pal) error
+type LifecycleHook[T any] func(ctx context.Context, service T, invoker Invoker) error
 
-// LifecycleHooks is a collection of hooks that can be registered to run at specific points in a service's lifecycle.
-type LifecycleHooks[T any] struct {
+// lifecycleHooks is a collection of hooks that can be registered to run at specific points in a service's lifecycle.
+type lifecycleHooks[T any] struct {
 	Init        LifecycleHook[T]
 	Shutdown    LifecycleHook[T]
 	HealthCheck LifecycleHook[T]
+}
+
+// Hookable is the fluent registration surface returned by [Provide], [ProvideNamed], [ProvideFn], and [ProvideNamedFn].
+// Concrete wrappers such as [ServiceConst] and [ServiceFnSingleton] remain exported for advanced use.
+type Hookable[T any] interface {
+	ServiceDef
+	ToInit(hook LifecycleHook[T]) Hookable[T]
+	ToShutdown(hook LifecycleHook[T]) Hookable[T]
+	ToHealthCheck(hook LifecycleHook[T]) Hookable[T]
 }

--- a/pal.go
+++ b/pal.go
@@ -13,13 +13,13 @@ import (
 	"time"
 )
 
-// ContextKey is a type used for context value keys to avoid collisions.
-type ContextKey int
+// contextKey is used for context value keys to avoid collisions.
+type contextKey int
 
 const (
-	// CtxValue is the key used to store and retrieve the Pal instance from a context.
-	// This allows services to access the Pal instance from a context passed to them.
-	CtxValue ContextKey = iota
+	// ctxValue is the key used to store and retrieve the Pal instance from a context.
+	// Use [WithPal] / [FromContext] rather than the key directly.
+	ctxValue contextKey = iota
 )
 
 // DefaultShutdownSignals is the default signals that will be used to shutdown the app.
@@ -58,9 +58,9 @@ func New(services ...ServiceDef) *Pal {
 	return pal
 }
 
-// FromContext retrieves a *Pal from the provided context, expecting it to be stored under the CtxValue key.
+// FromContext retrieves a *Pal from the provided context.
 func FromContext(ctx context.Context) (*Pal, error) {
-	invoker, ok := ctx.Value(CtxValue).(*Pal)
+	invoker, ok := ctx.Value(ctxValue).(*Pal)
 	if !ok {
 		return nil, ErrInvokerIsNotInContext
 	}
@@ -74,7 +74,7 @@ func MustFromContext(ctx context.Context) *Pal {
 }
 
 func WithPal(ctx context.Context, pal *Pal) context.Context {
-	return context.WithValue(ctx, CtxValue, pal)
+	return context.WithValue(ctx, ctxValue, pal)
 }
 
 // InitTimeout sets the timeout for the initialization of the services.
@@ -217,7 +217,8 @@ func (p *Pal) Run(ctx context.Context, signals ...os.Signal) error {
 }
 
 // Services returns a map of all registered services in the container, keyed by their names.
-// This can be useful for debugging or introspection purposes.
+//
+// Advanced: useful for debugging or introspection; prefer [Invoke] / [InvokeByInterface] for normal resolution.
 func (p *Pal) Services() map[string]ServiceDef {
 	return p.container.Services()
 }
@@ -250,7 +251,8 @@ func (p *Pal) InjectInto(ctx context.Context, target any) error {
 }
 
 // Container returns the underlying Container instance.
-// This can be useful for advanced use cases where direct access to the container is needed.
+//
+// Advanced: for power users who need direct container access; may change more freely than Provide/Pal.
 func (p *Pal) Container() *Container {
 	return p.container
 }

--- a/pal_prefixed_lifecycle_test.go
+++ b/pal_prefixed_lifecycle_test.go
@@ -183,7 +183,7 @@ func TestPalPrefixed_ToInitHookOverridesPalInit(t *testing.T) {
 	s := &palInitWithHook{}
 	hookCalled := false
 
-	p := newPal(pal.Provide(s).ToInit(func(_ context.Context, _ *palInitWithHook, _ *pal.Pal) error {
+	p := newPal(pal.Provide(s).ToInit(func(_ context.Context, _ *palInitWithHook, _ pal.Invoker) error {
 		hookCalled = true
 		return nil
 	}))

--- a/pal_test.go
+++ b/pal_test.go
@@ -268,7 +268,7 @@ func TestPal_Run(t *testing.T) {
 
 		// Create a service that will fail during initialization
 		failingService := pal.Provide(NewMockTestServiceStruct(t)).
-			ToInit(func(_ context.Context, _ *TestServiceStruct, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *TestServiceStruct, _ pal.Invoker) error {
 				return errTest
 			})
 

--- a/runners.go
+++ b/runners.go
@@ -17,6 +17,8 @@ var ErrNoMainRunners = errors.New("no main runners found")
 // It returns ErrNoMainRunners if no main runners among the services.
 // if any of the runners fail, the error is returned and and all other runners are stopped
 // by cancelling the context passed to them.
+//
+// Advanced: [Pal.Run] already schedules runners; use RunServices for custom run loops.
 func RunServices(ctx context.Context, services []ServiceDef) error {
 	mainRunners, secondaryRunners := getRunners(services)
 

--- a/service_const.go
+++ b/service_const.go
@@ -6,10 +6,12 @@ import (
 
 // ServiceConst is a service that wraps a constant value.
 // It is used to register existing instances as services.
+//
+// Advanced: prefer [Provide] / [Hookable] for normal registration; this type remains exported for power users.
 type ServiceConst[T any] struct {
 	ServiceTyped[T]
 
-	hooks LifecycleHooks[T]
+	hooks lifecycleHooks[T]
 
 	instance T
 }
@@ -58,7 +60,7 @@ func (c *ServiceConst[T]) Instance(_ context.Context, _ ...any) (any, error) {
 // ToInit registers a hook function that will be called to initialize the service.
 // This hook is called after the service is injected with its dependencies.
 // If the service implements [PalIniter] or [Initer], those init methods are not called; the hook has higher priority.
-func (c *ServiceConst[T]) ToInit(hook LifecycleHook[T]) *ServiceConst[T] {
+func (c *ServiceConst[T]) ToInit(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.Init = hook
 	return c
 }
@@ -66,14 +68,14 @@ func (c *ServiceConst[T]) ToInit(hook LifecycleHook[T]) *ServiceConst[T] {
 // ToShutdown registers a hook function that will be called to shutdown the service.
 // This hook is called before service's dependencies are shutdown.
 // If the service implements [PalShutdowner] or [Shutdowner], those shutdown methods are not called; the hook has higher priority.
-func (c *ServiceConst[T]) ToShutdown(hook LifecycleHook[T]) *ServiceConst[T] {
+func (c *ServiceConst[T]) ToShutdown(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.Shutdown = hook
 	return c
 }
 
 // ToHealthCheck registers a hook function that will be called to perform a health check on the service.
 // If the service implements [PalHealthChecker] or [HealthChecker], those health check methods are not called; the hook has higher priority.
-func (c *ServiceConst[T]) ToHealthCheck(hook LifecycleHook[T]) *ServiceConst[T] {
+func (c *ServiceConst[T]) ToHealthCheck(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.HealthCheck = hook
 	return c
 }

--- a/service_const_test.go
+++ b/service_const_test.go
@@ -59,7 +59,7 @@ func TestService_ToInit(t *testing.T) {
 
 		var hookCalled bool
 		service := pal.Provide(NewMockTestServiceStruct(t)).
-			ToInit(func(_ context.Context, _ *TestServiceStruct, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *TestServiceStruct, _ pal.Invoker) error {
 				hookCalled = true
 				return nil
 			})
@@ -100,7 +100,7 @@ func TestService_ToInit(t *testing.T) {
 		t.Parallel()
 
 		service := pal.Provide(NewMockTestServiceStruct(t)).
-			ToInit(func(_ context.Context, _ *TestServiceStruct, _ *pal.Pal) error {
+			ToInit(func(_ context.Context, _ *TestServiceStruct, _ pal.Invoker) error {
 				return errTest
 			})
 		p := newPal(service)

--- a/service_factory.go
+++ b/service_factory.go
@@ -2,6 +2,9 @@ package pal
 
 import "reflect"
 
+// ServiceFactory is the shared base for arity-specific factory wrappers.
+//
+// Advanced: prefer [ProvideFactory0]–[ProvideFactory5]; this type remains exported for power users.
 type ServiceFactory[I any, T any] struct {
 	ServiceTyped[I]
 }

--- a/service_factory0_test.go
+++ b/service_factory0_test.go
@@ -89,7 +89,7 @@ func TestServiceFactory0_Invocation(t *testing.T) {
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(t.Context()))
 
-		fn := service.Factory().(func(context.Context) (*factoryMultiLabel, error))
+		fn := service.(*pal.ServiceFactory0[*factoryMultiLabel, *factoryMultiLabel]).Factory().(func(context.Context) (*factoryMultiLabel, error))
 		_, err := fn(ctx)
 		assert.ErrorIs(t, err, errTest)
 	})
@@ -104,7 +104,7 @@ func TestServiceFactory0_Invocation(t *testing.T) {
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(t.Context()))
 
-		fn := service.Factory().(func(context.Context) (*factoryMultiLabel, error))
+		fn := service.(*pal.ServiceFactory0[*factoryMultiLabel, *factoryMultiLabel]).Factory().(func(context.Context) (*factoryMultiLabel, error))
 		got, err := fn(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "f0", got.S0)
@@ -120,7 +120,7 @@ func TestServiceFactory0_Invocation(t *testing.T) {
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(t.Context()))
 
-		mustFn := service.MustFactory().(func(context.Context) *factoryMultiLabel)
+		mustFn := service.(*pal.ServiceFactory0[*factoryMultiLabel, *factoryMultiLabel]).MustFactory().(func(context.Context) *factoryMultiLabel)
 		assert.PanicsWithValue(t, errTest, func() { mustFn(ctx) })
 	})
 }

--- a/service_factory1_test.go
+++ b/service_factory1_test.go
@@ -203,7 +203,7 @@ func TestServiceFactory1_FactoryAndMustFactory(t *testing.T) {
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(t.Context()))
 
-		fn := service.Factory().(func(context.Context, string) (*factory1Service, error))
+		fn := service.(*pal.ServiceFactory1[*factory1Service, *factory1Service, string]).Factory().(func(context.Context, string) (*factory1Service, error))
 		_, err := fn(ctx, "x")
 		assert.ErrorIs(t, err, errTest)
 	})
@@ -218,7 +218,7 @@ func TestServiceFactory1_FactoryAndMustFactory(t *testing.T) {
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(t.Context()))
 
-		mustFn := service.MustFactory().(func(context.Context, string) *factory1Service)
+		mustFn := service.(*pal.ServiceFactory1[*factory1Service, *factory1Service, string]).MustFactory().(func(context.Context, string) *factory1Service)
 		assert.PanicsWithValue(t, errTest, func() { mustFn(ctx, "x") })
 	})
 }

--- a/service_factory2_test.go
+++ b/service_factory2_test.go
@@ -121,7 +121,7 @@ func TestServiceFactory2_FactoryClosures(t *testing.T) {
 	ctxW := pal.WithPal(ctx, p)
 	require.NoError(t, p.Init(ctx))
 
-	f := s.Factory().(func(context.Context, string, int) (*factoryMultiLabel, error))
+	f := s.(*pal.ServiceFactory2[*factoryMultiLabel, *factoryMultiLabel, string, int]).Factory().(func(context.Context, string, int) (*factoryMultiLabel, error))
 	got, err := f(ctxW, "hi", 3)
 	require.NoError(t, err)
 	assert.Equal(t, "hi", got.S0)
@@ -130,6 +130,6 @@ func TestServiceFactory2_FactoryClosures(t *testing.T) {
 	_, err = f(ctxW, "err", 0)
 	assert.ErrorIs(t, err, errTest)
 
-	must := s.MustFactory().(func(context.Context, string, int) *factoryMultiLabel)
+	must := s.(*pal.ServiceFactory2[*factoryMultiLabel, *factoryMultiLabel, string, int]).MustFactory().(func(context.Context, string, int) *factoryMultiLabel)
 	assert.PanicsWithValue(t, errTest, func() { must(ctxW, "err", 0) })
 }

--- a/service_factory3_test.go
+++ b/service_factory3_test.go
@@ -125,7 +125,7 @@ func TestServiceFactory3_FactoryClosures(t *testing.T) {
 	ctxW := pal.WithPal(ctx, p)
 	require.NoError(t, p.Init(ctx))
 
-	f := s.Factory().(func(context.Context, string, int, string) (*factoryMultiLabel, error))
+	f := s.(*pal.ServiceFactory3[*factoryMultiLabel, *factoryMultiLabel, string, int, string]).Factory().(func(context.Context, string, int, string) (*factoryMultiLabel, error))
 	got, err := f(ctxW, "ok", 1, "c")
 	require.NoError(t, err)
 	assert.Equal(t, "c", got.S1)
@@ -133,6 +133,6 @@ func TestServiceFactory3_FactoryClosures(t *testing.T) {
 	_, err = f(ctxW, "err", 0, "")
 	assert.ErrorIs(t, err, errTest)
 
-	must := s.MustFactory().(func(context.Context, string, int, string) *factoryMultiLabel)
+	must := s.(*pal.ServiceFactory3[*factoryMultiLabel, *factoryMultiLabel, string, int, string]).MustFactory().(func(context.Context, string, int, string) *factoryMultiLabel)
 	assert.PanicsWithValue(t, errTest, func() { must(ctxW, "err", 0, "") })
 }

--- a/service_factory4_test.go
+++ b/service_factory4_test.go
@@ -140,7 +140,7 @@ func TestServiceFactory4_FactoryClosures(t *testing.T) {
 	ctxW := pal.WithPal(ctx, p)
 	require.NoError(t, p.Init(ctx))
 
-	f := s.Factory().(func(context.Context, string, int, string, bool) (*factoryMultiLabel, error))
+	f := s.(*pal.ServiceFactory4[*factoryMultiLabel, *factoryMultiLabel, string, int, string, bool]).Factory().(func(context.Context, string, int, string, bool) (*factoryMultiLabel, error))
 	got, err := f(ctxW, "a", 2, "c", true)
 	require.NoError(t, err)
 	assert.True(t, got.B)
@@ -148,6 +148,6 @@ func TestServiceFactory4_FactoryClosures(t *testing.T) {
 	_, err = f(ctxW, "a", 2, "c", false)
 	assert.ErrorIs(t, err, errTest)
 
-	must := s.MustFactory().(func(context.Context, string, int, string, bool) *factoryMultiLabel)
+	must := s.(*pal.ServiceFactory4[*factoryMultiLabel, *factoryMultiLabel, string, int, string, bool]).MustFactory().(func(context.Context, string, int, string, bool) *factoryMultiLabel)
 	assert.PanicsWithValue(t, errTest, func() { must(ctxW, "a", 2, "c", false) })
 }

--- a/service_factory5_test.go
+++ b/service_factory5_test.go
@@ -152,7 +152,7 @@ func TestServiceFactory5_FactoryClosures(t *testing.T) {
 	ctxW := pal.WithPal(ctx, p)
 	require.NoError(t, p.Init(ctx))
 
-	f := s.Factory().(func(context.Context, string, int, string, bool, rune) (*factoryMultiLabel, error))
+	f := s.(*pal.ServiceFactory5[*factoryMultiLabel, *factoryMultiLabel, string, int, string, bool, rune]).Factory().(func(context.Context, string, int, string, bool, rune) (*factoryMultiLabel, error))
 	got, err := f(ctxW, "a", 1, "b", true, 'x')
 	require.NoError(t, err)
 	assert.Equal(t, 'x', got.R)
@@ -164,10 +164,10 @@ func TestServiceFactory5_FactoryClosures(t *testing.T) {
 	ctxW2 := pal.WithPal(ctx, p2)
 	require.NoError(t, p2.Init(ctx))
 
-	f2 := sErr.Factory().(func(context.Context, string, int, string, bool, rune) (*factoryMultiLabel, error))
+	f2 := sErr.(*pal.ServiceFactory5[*factoryMultiLabel, *factoryMultiLabel, string, int, string, bool, rune]).Factory().(func(context.Context, string, int, string, bool, rune) (*factoryMultiLabel, error))
 	_, err = f2(ctxW2, "a", 1, "b", true, 'x')
 	assert.ErrorIs(t, err, errTest)
 
-	must := sErr.MustFactory().(func(context.Context, string, int, string, bool, rune) *factoryMultiLabel)
+	must := sErr.(*pal.ServiceFactory5[*factoryMultiLabel, *factoryMultiLabel, string, int, string, bool, rune]).MustFactory().(func(context.Context, string, int, string, bool, rune) *factoryMultiLabel)
 	assert.PanicsWithValue(t, errTest, func() { must(ctxW2, "a", 1, "b", true, 'x') })
 }

--- a/service_fn_singleton.go
+++ b/service_fn_singleton.go
@@ -6,11 +6,13 @@ import (
 
 // ServiceFnSingleton is a singleton service that is created using a function.
 // It is created during initialization and reused for the lifetime of the application.
+//
+// Advanced: prefer [ProvideFn] / [Hookable] for normal registration; this type remains exported for power users.
 type ServiceFnSingleton[I, T any] struct {
 	ServiceFactory[I, T]
 	fn func(ctx context.Context) (T, error)
 
-	hooks LifecycleHooks[T]
+	hooks lifecycleHooks[T]
 
 	instance T
 }
@@ -31,10 +33,23 @@ func (c *ServiceFnSingleton[I, T]) Run(ctx context.Context) error {
 }
 
 // Init initializes the service by calling the provided function to create the instance.
+// If a ToInit hook is set, it runs instead of [PalIniter] / [Initer] on the instance.
 func (c *ServiceFnSingleton[I, T]) Init(ctx context.Context) error {
 	instance, err := c.fn(ctx)
 	if err != nil {
 		return err
+	}
+
+	logger := c.P.logger.With("service", c.Name())
+
+	if c.hooks.Init != nil {
+		logger.Debug("Calling ToInit hook")
+		if err := c.hooks.Init(ctx, instance, c.P); err != nil {
+			logger.Error("Init hook failed", "error", err)
+			return err
+		}
+		c.instance = instance
+		return nil
 	}
 
 	if pi, ok := any(instance).(PalIniter); ok {
@@ -67,16 +82,23 @@ func (c *ServiceFnSingleton[I, T]) Instance(_ context.Context, _ ...any) (any, e
 	return c.instance, nil
 }
 
+// ToInit registers a hook called after the factory function creates the instance.
+// If the service implements [PalIniter] or [Initer], those methods are not called; the hook has higher priority.
+func (c *ServiceFnSingleton[I, T]) ToInit(hook LifecycleHook[T]) Hookable[T] {
+	c.hooks.Init = hook
+	return c
+}
+
 // ToShutdown registers a hook called during shutdown. If the service implements [PalShutdowner] or [Shutdowner],
 // those methods are not called; the hook has higher priority.
-func (c *ServiceFnSingleton[I, T]) ToShutdown(hook LifecycleHook[T]) *ServiceFnSingleton[I, T] {
+func (c *ServiceFnSingleton[I, T]) ToShutdown(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.Shutdown = hook
 	return c
 }
 
 // ToHealthCheck registers a hook function that will be called to perform a health check on the service.
 // If the service implements [PalHealthChecker] or [HealthChecker], those health check methods are not called; the hook has higher priority.
-func (c *ServiceFnSingleton[I, T]) ToHealthCheck(hook LifecycleHook[T]) *ServiceFnSingleton[I, T] {
+func (c *ServiceFnSingleton[I, T]) ToHealthCheck(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.HealthCheck = hook
 	return c
 }

--- a/service_fn_singleton_test.go
+++ b/service_fn_singleton_test.go
@@ -105,7 +105,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return nil, errTest
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		err := p.Init(pal.WithPal(t.Context(), p))
 		assert.ErrorIs(t, err, errTest)
@@ -117,7 +117,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		inst := &fnSingletonPalIniter{err: errTest}
 		s := pal.ProvideFn[*fnSingletonPalIniter](func(_ context.Context) (*fnSingletonPalIniter, error) {
 			return inst, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalIniter, *fnSingletonPalIniter])
 		p := newPal(s)
 		err := p.Init(pal.WithPal(t.Context(), p))
 		assert.ErrorIs(t, err, errTest)
@@ -130,7 +130,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		inst := &fnSingletonIniterOnly{err: errTest}
 		s := pal.ProvideFn[*fnSingletonIniterOnly](func(_ context.Context) (*fnSingletonIniterOnly, error) {
 			return inst, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonIniterOnly, *fnSingletonIniterOnly])
 		p := newPal(s)
 		err := p.Init(pal.WithPal(t.Context(), p))
 		assert.ErrorIs(t, err, errTest)
@@ -143,7 +143,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		inst := &fnSingletonBothInit{}
 		s := pal.ProvideFn[*fnSingletonBothInit](func(_ context.Context) (*fnSingletonBothInit, error) {
 			return inst, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonBothInit, *fnSingletonBothInit])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		assert.True(t, inst.called)
@@ -156,7 +156,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		inst := &fnSingletonPalIniter{}
 		s := pal.ProvideFn[*fnSingletonPalIniter](func(_ context.Context) (*fnSingletonPalIniter, error) {
 			return inst, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalIniter, *fnSingletonPalIniter])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		assert.True(t, inst.called)
@@ -168,7 +168,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		inst := &fnSingletonIniterOnly{}
 		s := pal.ProvideFn[*fnSingletonIniterOnly](func(_ context.Context) (*fnSingletonIniterOnly, error) {
 			return inst, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonIniterOnly, *fnSingletonIniterOnly])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		assert.True(t, inst.called)
@@ -179,7 +179,7 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return &fnSingletonPlain{N: 42}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 	})
@@ -191,7 +191,7 @@ func TestServiceFnSingleton_Instance(t *testing.T) {
 	inst := &fnSingletonPlain{N: 7}
 	s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 		return inst, nil
-	})
+	}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 	p := newPal(s)
 	ctx := pal.WithPal(t.Context(), p)
 	require.NoError(t, p.Init(ctx))
@@ -213,7 +213,7 @@ func TestServiceFnSingleton_Run(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return &fnSingletonPlain{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(ctx))
@@ -228,7 +228,7 @@ func TestServiceFnSingleton_Run(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonRunner](func(_ context.Context) (*fnSingletonRunner, error) {
 			return &fnSingletonRunner{MockRunner: mr}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonRunner, *fnSingletonRunner])
 		p := newPal(s)
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(ctx))
@@ -240,7 +240,7 @@ func TestServiceFnSingleton_Run(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPalRunner](func(_ context.Context) (*fnSingletonPalRunner, error) {
 			return &fnSingletonPalRunner{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalRunner, *fnSingletonPalRunner])
 		p := newPal(s)
 		ctx := pal.WithPal(t.Context(), p)
 		require.NoError(t, p.Init(ctx))
@@ -256,7 +256,7 @@ func TestServiceFnSingleton_ShouldWaitForRunner(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonRunConfiger](func(_ context.Context) (*fnSingletonRunConfiger, error) {
 			return &fnSingletonRunConfiger{wait: false}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonRunConfiger, *fnSingletonRunConfiger])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		require.NotNil(t, s.ShouldWaitForRunner())
@@ -268,7 +268,7 @@ func TestServiceFnSingleton_ShouldWaitForRunner(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPalRunConfiger](func(_ context.Context) (*fnSingletonPalRunConfiger, error) {
 			return &fnSingletonPalRunConfiger{wait: false}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalRunConfiger, *fnSingletonPalRunConfiger])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		require.NotNil(t, s.ShouldWaitForRunner())
@@ -280,7 +280,7 @@ func TestServiceFnSingleton_ShouldWaitForRunner(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonRunnerFromMake](func(_ context.Context) (*fnSingletonRunnerFromMake, error) {
 			return nil, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonRunnerFromMake, *fnSingletonRunnerFromMake])
 		_ = newPal(s)
 		// before Init, instance is nil *fnSingletonRunnerFromMake; Make still produces a concrete *T
 		require.NotNil(t, s.ShouldWaitForRunner())
@@ -292,7 +292,7 @@ func TestServiceFnSingleton_ShouldWaitForRunner(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPalRunnerFromMake](func(_ context.Context) (*fnSingletonPalRunnerFromMake, error) {
 			return nil, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalRunnerFromMake, *fnSingletonPalRunnerFromMake])
 		_ = newPal(s)
 		require.NotNil(t, s.ShouldWaitForRunner())
 		assert.True(t, *s.ShouldWaitForRunner())
@@ -303,7 +303,7 @@ func TestServiceFnSingleton_ShouldWaitForRunner(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return &fnSingletonPlain{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
 		assert.Nil(t, s.ShouldWaitForRunner())
@@ -322,7 +322,8 @@ func TestServiceFnSingleton_HealthCheck(t *testing.T) {
 		hookCalled := false
 		s := pal.ProvideFn[*fnSingletonPalHealth](func(_ context.Context) (*fnSingletonPalHealth, error) {
 			return inst, nil
-		}).ToHealthCheck(func(_ context.Context, got *fnSingletonPalHealth, _ *pal.Pal) error {
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalHealth, *fnSingletonPalHealth])
+		s.ToHealthCheck(func(_ context.Context, got *fnSingletonPalHealth, _ pal.Invoker) error {
 			hookCalled = true
 			assert.Same(t, inst, got)
 			return errTest
@@ -340,7 +341,7 @@ func TestServiceFnSingleton_HealthCheck(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPalHealth](func(_ context.Context) (*fnSingletonPalHealth, error) {
 			return &fnSingletonPalHealth{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalHealth, *fnSingletonPalHealth])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(ctx, p)))
 		assert.ErrorIs(t, s.HealthCheck(pal.WithPal(ctx, p)), errTest)
@@ -354,7 +355,7 @@ func TestServiceFnSingleton_HealthCheck(t *testing.T) {
 			out.MockIniter.EXPECT().Init(mock.Anything).Return(nil)
 			out.MockHealthChecker.EXPECT().HealthCheck(mock.Anything).Return(errTest)
 			return out, nil
-		})
+		}).(*pal.ServiceFnSingleton[*TestServiceStruct, *TestServiceStruct])
 		p := newPal(s)
 		wrapped := pal.WithPal(ctx, p)
 		require.NoError(t, p.Init(wrapped))
@@ -366,7 +367,7 @@ func TestServiceFnSingleton_HealthCheck(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return &fnSingletonPlain{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		wrapped := pal.WithPal(ctx, p)
 		require.NoError(t, p.Init(wrapped))
@@ -386,7 +387,8 @@ func TestServiceFnSingleton_Shutdown(t *testing.T) {
 		hookCalled := false
 		s := pal.ProvideFn[*fnSingletonPalShutdown](func(_ context.Context) (*fnSingletonPalShutdown, error) {
 			return inst, nil
-		}).ToShutdown(func(_ context.Context, got *fnSingletonPalShutdown, _ *pal.Pal) error {
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalShutdown, *fnSingletonPalShutdown])
+		s.ToShutdown(func(_ context.Context, got *fnSingletonPalShutdown, _ pal.Invoker) error {
 			hookCalled = true
 			assert.Same(t, inst, got)
 			return errTest
@@ -404,7 +406,7 @@ func TestServiceFnSingleton_Shutdown(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPalShutdown](func(_ context.Context) (*fnSingletonPalShutdown, error) {
 			return &fnSingletonPalShutdown{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPalShutdown, *fnSingletonPalShutdown])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(ctx, p)))
 		assert.ErrorIs(t, s.Shutdown(pal.WithPal(ctx, p)), errTest2)
@@ -418,7 +420,7 @@ func TestServiceFnSingleton_Shutdown(t *testing.T) {
 			out.MockIniter.EXPECT().Init(mock.Anything).Return(nil)
 			out.MockShutdowner.EXPECT().Shutdown(mock.Anything).Return(errTest)
 			return out, nil
-		})
+		}).(*pal.ServiceFnSingleton[*TestServiceStruct, *TestServiceStruct])
 		p := newPal(s)
 		wrapped := pal.WithPal(ctx, p)
 		require.NoError(t, p.Init(wrapped))
@@ -430,7 +432,7 @@ func TestServiceFnSingleton_Shutdown(t *testing.T) {
 
 		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 			return &fnSingletonPlain{}, nil
-		})
+		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		wrapped := pal.WithPal(ctx, p)
 		require.NoError(t, p.Init(wrapped))
@@ -443,13 +445,13 @@ func TestServiceFnSingleton_ToShutdown_ToHealthCheck_returnSelf(t *testing.T) {
 
 	s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
 		return &fnSingletonPlain{}, nil
-	})
-	s2 := s.ToShutdown(func(_ context.Context, _ *fnSingletonPlain, _ *pal.Pal) error {
+	}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
+	s2 := s.ToShutdown(func(_ context.Context, _ *fnSingletonPlain, _ pal.Invoker) error {
 		return nil
 	})
 	assert.Same(t, s, s2)
 
-	s3 := s.ToHealthCheck(func(_ context.Context, _ *fnSingletonPlain, _ *pal.Pal) error {
+	s3 := s.ToHealthCheck(func(_ context.Context, _ *fnSingletonPlain, _ pal.Invoker) error {
 		return nil
 	})
 	assert.Same(t, s, s3)

--- a/service_list.go
+++ b/service_list.go
@@ -6,6 +6,8 @@ import (
 )
 
 // ServiceList is a proxy service to a list of services.
+//
+// Advanced: prefer [ProvideList], which returns [ServiceDef]; this type remains exported for power users.
 type ServiceList struct {
 	ServiceTyped[any]
 	Services []ServiceDef

--- a/service_runner.go
+++ b/service_runner.go
@@ -8,6 +8,9 @@ import (
 
 const idCharset = "abcdefghijklmnopqrstuvwxyz0123456789"
 
+// ServiceRunner wraps an anonymous runner function registered via [ProvideRunner].
+//
+// Advanced: prefer [ProvideRunner], which returns [ServiceDef]; this type remains exported for power users.
 type ServiceRunner struct {
 	P *Pal
 	ServiceTyped[any]

--- a/service_runner_test.go
+++ b/service_runner_test.go
@@ -15,7 +15,7 @@ import (
 func TestServiceRunner_ShouldWaitForRunner(t *testing.T) {
 	t.Parallel()
 
-	r := pal.ProvideRunner(func(context.Context) error { return nil })
+	r := pal.ProvideRunner(func(context.Context) error { return nil }).(*pal.ServiceRunner)
 	require.NotNil(t, r.ShouldWaitForRunner())
 	assert.True(t, *r.ShouldWaitForRunner())
 }
@@ -30,7 +30,7 @@ func TestServiceRunner_Run(t *testing.T) {
 		r := pal.ProvideRunner(func(ctx context.Context) error {
 			got = ctx
 			return nil
-		})
+		}).(*pal.ServiceRunner)
 		r.P = newPal(r)
 		ctx := t.Context()
 		require.NoError(t, r.Run(ctx))
@@ -40,7 +40,7 @@ func TestServiceRunner_Run(t *testing.T) {
 	t.Run("returns fn error", func(t *testing.T) {
 		t.Parallel()
 
-		r := pal.ProvideRunner(func(context.Context) error { return errTest })
+		r := pal.ProvideRunner(func(context.Context) error { return errTest }).(*pal.ServiceRunner)
 		r.P = newPal(r)
 		assert.ErrorIs(t, r.Run(t.Context()), errTest)
 	})
@@ -49,7 +49,7 @@ func TestServiceRunner_Run(t *testing.T) {
 		t.Parallel()
 
 		const msg = "runner panic"
-		r := pal.ProvideRunner(func(context.Context) error { panic(msg) })
+		r := pal.ProvideRunner(func(context.Context) error { panic(msg) }).(*pal.ServiceRunner)
 		r.P = newPal(r)
 		err := r.Run(t.Context())
 		require.Error(t, err)
@@ -63,7 +63,7 @@ func TestServiceRunner_Run(t *testing.T) {
 func TestServiceRunner_Instance(t *testing.T) {
 	t.Parallel()
 
-	r := pal.ProvideRunner(func(context.Context) error { return nil })
+	r := pal.ProvideRunner(func(context.Context) error { return nil }).(*pal.ServiceRunner)
 	inst, err := r.Instance(t.Context())
 
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestServiceRunner_Name(t *testing.T) {
 	t.Parallel()
 
 	const prefix = "$function-runner-"
-	r := pal.ProvideRunner(func(context.Context) error { return nil })
+	r := pal.ProvideRunner(func(context.Context) error { return nil }).(*pal.ServiceRunner)
 	name := r.Name()
 
 	assert.True(t, strings.HasPrefix(name, prefix))

--- a/service_typed.go
+++ b/service_typed.go
@@ -1,5 +1,8 @@
 package pal
 
+// ServiceTyped is a shared base for Provide* wrappers.
+//
+// Advanced: exported for embedding/custom ServiceDef implementations.
 type ServiceTyped[T any] struct {
 	P    *Pal
 	name string

--- a/tags.go
+++ b/tags.go
@@ -7,6 +7,8 @@ import (
 
 type Tag string
 
+// Struct-tag names recognized on `pal:"..."` field tags. Prefer these constants when documenting tags;
+// parsing is handled internally during injection.
 const (
 	TagSkip           Tag = "skip"
 	TagMatchInterface Tag = "match_interface"
@@ -19,7 +21,7 @@ var supportedTags = map[Tag]bool{
 	TagName:           true,
 }
 
-func ParseTag(tags string) (map[Tag]string, error) {
+func parseTag(tags string) (map[Tag]string, error) {
 	tagMap := make(map[Tag]string)
 	tags = strings.ReplaceAll(tags, " ", "")
 	if tags == "" {

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,10 +1,9 @@
-package pal_test
+package pal
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zhulik/pal"
 )
 
 // TestParseTag tests the ParseTag function
@@ -14,66 +13,66 @@ func TestParseTag(t *testing.T) {
 	t.Run("parses single tag without value", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("skip")
+		tags, err := parseTag("skip")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagSkip: "",
+		assert.Equal(t, map[Tag]string{
+			TagSkip: "",
 		}, tags)
 	})
 
 	t.Run("parses single tag with value", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("name=MyService")
+		tags, err := parseTag("name=MyService")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagName: "MyService",
+		assert.Equal(t, map[Tag]string{
+			TagName: "MyService",
 		}, tags)
 	})
 
 	t.Run("parses multiple tags without values", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("skip,match_interface")
+		tags, err := parseTag("skip,match_interface")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagSkip:           "",
-			pal.TagMatchInterface: "",
+		assert.Equal(t, map[Tag]string{
+			TagSkip:           "",
+			TagMatchInterface: "",
 		}, tags)
 	})
 
 	t.Run("parses multiple tags with values", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("name=MyService,match_interface=MyInterface")
+		tags, err := parseTag("name=MyService,match_interface=MyInterface")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagName:           "MyService",
-			pal.TagMatchInterface: "MyInterface",
+		assert.Equal(t, map[Tag]string{
+			TagName:           "MyService",
+			TagMatchInterface: "MyInterface",
 		}, tags)
 	})
 
 	t.Run("parses mixed tags with and without values", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("skip,name=MyService,match_interface")
+		tags, err := parseTag("skip,name=MyService,match_interface")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagSkip:           "",
-			pal.TagName:           "MyService",
-			pal.TagMatchInterface: "",
+		assert.Equal(t, map[Tag]string{
+			TagSkip:           "",
+			TagName:           "MyService",
+			TagMatchInterface: "",
 		}, tags)
 	})
 
 	t.Run("handles empty input as unsupported tag", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("")
+		tags, err := parseTag("")
 
 		assert.NoError(t, err)
 		assert.Empty(t, tags)
@@ -82,91 +81,91 @@ func TestParseTag(t *testing.T) {
 	t.Run("handles whitespace around tags as unsupported tags", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag(" skip , name=MyService ")
+		tags, err := parseTag(" skip , name=MyService ")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagSkip: "",
-			pal.TagName: "MyService",
+		assert.Equal(t, map[Tag]string{
+			TagSkip: "",
+			TagName: "MyService",
 		}, tags)
 	})
 
 	t.Run("returns error for unsupported tag", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("unsupported")
+		_, err := parseTag("unsupported")
 
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 		assert.Contains(t, err.Error(), "tag unsupported unsupported")
 	})
 
 	t.Run("returns error for unsupported tag in multiple tags", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("skip,unsupported,name=MyService")
+		_, err := parseTag("skip,unsupported,name=MyService")
 
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 		assert.Contains(t, err.Error(), "tag unsupported unsupported")
 	})
 
 	t.Run("handles tag with multiple equals signs correctly", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("name=key=value=extra")
+		_, err := parseTag("name=key=value=extra")
 
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 		assert.Contains(t, err.Error(), "tag is malformed name=key=value=extra")
 	})
 
 	t.Run("returns error for tag with only equals", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("=")
+		_, err := parseTag("=")
 
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 		assert.Contains(t, err.Error(), "tag unsupported ")
 	})
 
 	t.Run("handles tag with multiple equals", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("name==")
+		_, err := parseTag("name==")
 
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 	})
 
 	t.Run("handles tag with no value correctly", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := pal.ParseTag("name=")
+		_, err := parseTag("name=")
 
-		assert.ErrorIs(t, err, pal.ErrInvalidTag)
+		assert.ErrorIs(t, err, ErrInvalidTag)
 	})
 
 	t.Run("handles all supported tags", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("skip,name=TestService,match_interface=TestInterface")
+		tags, err := parseTag("skip,name=TestService,match_interface=TestInterface")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagSkip:           "",
-			pal.TagName:           "TestService",
-			pal.TagMatchInterface: "TestInterface",
+		assert.Equal(t, map[Tag]string{
+			TagSkip:           "",
+			TagName:           "TestService",
+			TagMatchInterface: "TestInterface",
 		}, tags)
 	})
 
 	t.Run("handles duplicate tags by overwriting", func(t *testing.T) {
 		t.Parallel()
 
-		tags, err := pal.ParseTag("name=FirstService,name=SecondService")
+		tags, err := parseTag("name=FirstService,name=SecondService")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[pal.Tag]string{
-			pal.TagName: "SecondService",
+		assert.Equal(t, map[Tag]string{
+			TagName: "SecondService",
 		}, tags)
 	})
 }

--- a/tree_json.go
+++ b/tree_json.go
@@ -1,0 +1,121 @@
+package pal
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/zhulik/pal/pkg/dag"
+)
+
+// TreeJSON is the JSON shape of a dependency graph (nodes and edges).
+// Advanced: useful for custom visualizers; [inspect] uses [Pal.TreeJSON].
+type TreeJSON struct {
+	Nodes []TreeNodeJSON `json:"nodes"`
+	Edges []TreeEdgeJSON `json:"edges"`
+}
+
+// TreeNodeJSON describes one service vertex in [TreeJSON].
+type TreeNodeJSON struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	InDegree  int    `json:"inDegree"`
+	OutDegree int    `json:"outDegree"`
+
+	Initer        bool `json:"initer"`
+	Runner        bool `json:"runner"`
+	RunConfiger   bool `json:"runConfiger"`
+	HealthChecker bool `json:"healthChecker"`
+	Shutdowner    bool `json:"shutdowner"`
+}
+
+// TreeEdgeJSON describes one dependency edge in [TreeJSON].
+type TreeEdgeJSON struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+func serviceToTreeNodeJSON(id string, inDegree int, outDegree int, service ServiceDef) TreeNodeJSON {
+	var initer, runner, runConfiger, healthChecker, shutdowner bool
+
+	instance := service.Make()
+
+	if _, ok := instance.(PalIniter); ok {
+		initer = true
+	} else if _, ok := instance.(Initer); ok {
+		initer = true
+	}
+
+	if _, ok := instance.(PalRunner); ok {
+		runner = true
+	} else if _, ok := instance.(Runner); ok {
+		runner = true
+	}
+
+	if _, ok := instance.(PalRunConfiger); ok {
+		runConfiger = true
+	} else if _, ok := instance.(RunConfiger); ok {
+		runConfiger = true
+	}
+
+	if _, ok := instance.(PalHealthChecker); ok {
+		healthChecker = true
+	} else if _, ok := instance.(HealthChecker); ok {
+		healthChecker = true
+	}
+
+	if _, ok := instance.(PalShutdowner); ok {
+		shutdowner = true
+	} else if _, ok := instance.(Shutdowner); ok {
+		shutdowner = true
+	}
+
+	idParts := strings.Split(id, "/")
+	label := idParts[len(idParts)-1]
+
+	if strings.HasPrefix(id, "*") {
+		label = "*" + label
+	}
+
+	return TreeNodeJSON{
+		ID:        id,
+		Label:     label,
+		InDegree:  inDegree,
+		OutDegree: outDegree,
+
+		Initer:        initer,
+		Runner:        runner,
+		RunConfiger:   runConfiger,
+		HealthChecker: healthChecker,
+		Shutdowner:    shutdowner,
+	}
+}
+
+// GraphToJSON encodes a dependency DAG as JSON.
+// Advanced: prefer [Pal.TreeJSON] unless you already hold a [dag.DAG].
+func GraphToJSON(d *dag.DAG[string, ServiceDef]) ([]byte, error) {
+	var nodes []TreeNodeJSON
+	var edges []TreeEdgeJSON
+
+	for id, service := range d.Vertices() {
+		nodes = append(nodes, serviceToTreeNodeJSON(id, d.GetInDegree(id), len(d.Edges()[id]), service))
+	}
+
+	for from, targets := range d.Edges() {
+		for to := range targets {
+			edges = append(edges, TreeEdgeJSON{
+				From: from,
+				To:   to,
+			})
+		}
+	}
+
+	return json.Marshal(TreeJSON{
+		Nodes: nodes,
+		Edges: edges,
+	})
+}
+
+// TreeJSON returns a JSON encoding of this Pal instance's dependency graph.
+func (p *Pal) TreeJSON() ([]byte, error) {
+	return GraphToJSON(p.container.Graph())
+}


### PR DESCRIPTION
## Summary

Make the default public API interface-first while keeping concrete wrappers and Container importable for advanced/hackable use.

## Changes

- `Provide` / `ProvideFn` (and named variants) return `Hookable[T]`; factories/runner/list return `ServiceDef`
- `LifecycleHook` takes `Invoker` instead of `*Pal`; `ProvideFn` gains `ToInit` with hook priority
- Unexport `parseTag` and context key plumbing (`WithPal` / `FromContext` only)
- Add `Pal.TreeJSON()` / `GraphToJSON`; inspect uses `TreeJSON()` instead of `Container().Graph()`
- Godoc/README: primary path vs Advanced escape hatches; concretes stay exported

## How To Test

```bash
task lint-fix
go test ./...
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact

**Migration:** update hook signatures to `pal.Invoker`; stop naming concrete Provide return types (or type-assert); use `FromContext` instead of `CtxValue`; prefer `Pal.TreeJSON()` over inspect+Container for the dependency UI.