### PR TITLE
fix!: inject dependencies in ProvideFn singleton init

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ a few rules described below.
 Pal provides several functions for registering services. They return interfaces (`Hookable` or `ServiceDef`) so the default path stays implementation-agnostic:
 
 - `Provide[T any](value T) Hookable[T]` - Registers an instance of a service; chain `ToInit` / `ToShutdown` / `ToHealthCheck` as needed.
-- `ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) Hookable[T]` - Registers a singleton built with the provided function.
+- `ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) Hookable[T]` - Registers a singleton built with the provided function; after create, uses the same inject → ToInit / Init pipeline as `Provide`.
 - `ProvideFactory{0-5}[...](...) ServiceDef` - Registers a factory service created with the provided function (0–5 args).
 - `ProvideRunner(fn) ServiceDef` - Registers an anonymous background runner.
 - `ProvideList(...ServiceDef) ServiceDef` - Registers multiple services at once, useful when splitting apps into modules, see [example](./examples/web)

--- a/api.go
+++ b/api.go
@@ -28,11 +28,14 @@ func ProvideNamed[T any](name string, value T) Hookable[T] {
 }
 
 // ProvideFn registers a singleton built with a given function.
+// After the function returns, Pal injects dependencies into the instance and calls
+// [Initer] / [PalIniter] unless a ToInit hook is set (same pipeline as [Provide]).
 func ProvideFn[I any, T any](fn func(ctx context.Context) (T, error)) Hookable[T] {
 	return ProvideNamedFn[I](typetostring.GetType[I](), fn)
 }
 
 // ProvideNamedFn registers a singleton built with a given function under a custom name.
+// Lifecycle matches [ProvideFn]: create → inject → ToInit / PalInit / Init.
 func ProvideNamedFn[I any, T any](name string, fn func(ctx context.Context) (T, error)) Hookable[T] {
 	validateFactoryFunction[I, T](fn)
 

--- a/service_const.go
+++ b/service_const.go
@@ -31,8 +31,8 @@ func (c *ServiceConst[T]) Run(ctx context.Context) error {
 	return runService(ctx, c.Name(), c.instance, c.P)
 }
 
-// Init is a no-op for const services as they are already initialized.
-// It injects dependencies to the stored instance and calls its Init method if it implements Initer.
+// Init injects dependencies into the stored instance, then runs ToInit / PalInit / Init.
+// Same post-create pipeline as [ServiceFnSingleton.Init].
 func (c *ServiceConst[T]) Init(ctx context.Context) error {
 	return initService(ctx, c.Name(), c.instance, c.hooks.Init, c.P)
 }

--- a/service_fn_singleton.go
+++ b/service_fn_singleton.go
@@ -32,38 +32,19 @@ func (c *ServiceFnSingleton[I, T]) Run(ctx context.Context) error {
 	return runService(ctx, c.Name(), c.instance, c.P)
 }
 
-// Init initializes the service by calling the provided function to create the instance.
-// If a ToInit hook is set, it runs instead of [PalIniter] / [Initer] on the instance.
+// Init creates the singleton via the factory function, then runs the same pipeline as
+// [ServiceConst.Init]: inject dependencies, then ToInit / PalInit / Init.
 func (c *ServiceFnSingleton[I, T]) Init(ctx context.Context) error {
 	instance, err := c.fn(ctx)
 	if err != nil {
 		return err
 	}
 
-	logger := c.P.logger.With("service", c.Name())
-
-	if c.hooks.Init != nil {
-		logger.Debug("Calling ToInit hook")
-		if err := c.hooks.Init(ctx, instance, c.P); err != nil {
-			logger.Error("Init hook failed", "error", err)
-			return err
-		}
-		c.instance = instance
-		return nil
-	}
-
-	if pi, ok := any(instance).(PalIniter); ok {
-		if err := pi.PalInit(ctx); err != nil {
-			return err
-		}
-	} else if initer, ok := any(instance).(Initer); ok {
-		if err := initer.Init(ctx); err != nil {
-			return err
-		}
+	if err := initService(ctx, c.Name(), instance, c.hooks.Init, c.P); err != nil {
+		return err
 	}
 
 	c.instance = instance
-
 	return nil
 }
 
@@ -82,8 +63,9 @@ func (c *ServiceFnSingleton[I, T]) Instance(_ context.Context, _ ...any) (any, e
 	return c.instance, nil
 }
 
-// ToInit registers a hook called after the factory function creates the instance.
-// If the service implements [PalIniter] or [Initer], those methods are not called; the hook has higher priority.
+// ToInit registers a hook called after the factory function creates the instance and
+// dependencies are injected. If the service implements [PalIniter] or [Initer], those
+// methods are not called; the hook has higher priority.
 func (c *ServiceFnSingleton[I, T]) ToInit(hook LifecycleHook[T]) Hookable[T] {
 	c.hooks.Init = hook
 	return c

--- a/service_fn_singleton_test.go
+++ b/service_fn_singleton_test.go
@@ -97,6 +97,20 @@ func (b *fnSingletonBothInit) Init(_ context.Context) error {
 	return nil
 }
 
+type fnSingletonWithDep struct {
+	Dep *fnSingletonPlain
+}
+
+type fnSingletonWithDepIniter struct {
+	Dep        *fnSingletonPlain
+	initCalled bool
+}
+
+func (s *fnSingletonWithDepIniter) Init(_ context.Context) error {
+	s.initCalled = true
+	return nil
+}
+
 func TestServiceFnSingleton_Init(t *testing.T) {
 	t.Parallel()
 
@@ -182,6 +196,50 @@ func TestServiceFnSingleton_Init(t *testing.T) {
 		}).(*pal.ServiceFnSingleton[*fnSingletonPlain, *fnSingletonPlain])
 		p := newPal(s)
 		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
+	})
+
+	t.Run("injects dependencies before Init", func(t *testing.T) {
+		t.Parallel()
+
+		s := pal.ProvideFn[*fnSingletonWithDep](func(_ context.Context) (*fnSingletonWithDep, error) {
+			return &fnSingletonWithDep{}, nil
+		}).(*pal.ServiceFnSingleton[*fnSingletonWithDep, *fnSingletonWithDep])
+		p := newPal(pal.Provide(&fnSingletonPlain{N: 1}), s)
+		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
+
+		inst, err := s.Instance(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, inst.(*fnSingletonWithDep).Dep)
+		assert.Equal(t, 1, inst.(*fnSingletonWithDep).Dep.N)
+	})
+
+	t.Run("ToInit runs after injection and skips Init", func(t *testing.T) {
+		t.Parallel()
+
+		inst := &fnSingletonWithDepIniter{}
+		hookSawDep := false
+		s := pal.ProvideFn[*fnSingletonWithDepIniter](func(_ context.Context) (*fnSingletonWithDepIniter, error) {
+			return inst, nil
+		}).ToInit(func(_ context.Context, got *fnSingletonWithDepIniter, _ pal.Invoker) error {
+			hookSawDep = got.Dep != nil
+			return nil
+		})
+		p := newPal(pal.Provide(&fnSingletonPlain{N: 2}), s)
+		require.NoError(t, p.Init(pal.WithPal(t.Context(), p)))
+		assert.True(t, hookSawDep)
+		assert.False(t, inst.initCalled)
+	})
+
+	t.Run("ToInit error is propagated", func(t *testing.T) {
+		t.Parallel()
+
+		s := pal.ProvideFn[*fnSingletonPlain](func(_ context.Context) (*fnSingletonPlain, error) {
+			return &fnSingletonPlain{}, nil
+		}).ToInit(func(_ context.Context, _ *fnSingletonPlain, _ pal.Invoker) error {
+			return errTest
+		})
+		p := newPal(s)
+		assert.ErrorIs(t, p.Init(pal.WithPal(t.Context(), p)), errTest)
 	})
 }
 


### PR DESCRIPTION
## Summary

Unify `Provide` and `ProvideFn` singleton lifecycle: after the factory function creates an instance, `ProvideFn` now runs the same `initService` pipeline as `Provide` (inject → ToInit / PalInit / Init). Docs already described this; fn-singletons previously skipped field injection.

## Changes

- Route `ServiceFnSingleton.Init` through `initService`
- Document the shared pipeline on `ProvideFn` / `ProvideNamedFn` and in the README
- Add tests for injection and `ToInit` override on the fn path

## How To Test

```bash
task lint-fix
go test ./...
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact