### PR TITLE
fix: derive Pal service name via typetostring

### DIFF
--- a/api.go
+++ b/api.go
@@ -152,7 +152,7 @@ func ProvideNamedFactory5[I any, T any, P1 any, P2 any, P3 any, P4 any, P5 any](
 func ProvidePal(pal *Pal) ServiceDef {
 	services := make([]ServiceDef, 0, len(pal.Services()))
 	for _, v := range pal.Services() {
-		if v.Name() != "*github.com/zhulik/pal.Pal" {
+		if v.Name() != palServiceName() {
 			services = append(services, v)
 		}
 	}

--- a/container.go
+++ b/container.go
@@ -253,7 +253,7 @@ func (c *Container) HealthCheck(ctx context.Context) error {
 	for _, service := range c.graph.TopologicalOrder() {
 		wg.Go(func() error {
 			// Do not check pal again, this leads to recursion
-			if service.Name() == "*github.com/zhulik/pal.Pal" {
+			if service.Name() == palServiceName() {
 				return nil
 			}
 

--- a/pal.go
+++ b/pal.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	typetostring "github.com/samber/go-type-to-string"
 )
 
 // contextKey is used for context value keys to avoid collisions.
@@ -56,6 +58,10 @@ func New(services ...ServiceDef) *Pal {
 	pal.container = NewContainer(pal, services...)
 
 	return pal
+}
+
+func palServiceName() string {
+	return typetostring.GetType[*Pal]()
 }
 
 // FromContext retrieves a *Pal from the provided context.


### PR DESCRIPTION
## Summary

Derive the Pal service name with `typetostring.GetType[*Pal]()` instead of hardcoding `*github.com/zhulik/pal.Pal`, so `ProvidePal` and `HealthCheck` stay aligned with how Pal is registered.

## Changes

- Add unexported `palServiceName()` helper
- Use it in `ProvidePal` and `Container.HealthCheck`

## How To Test

```bash
task lint-fix
go test ./...
```

## Checklist

- [x] Tests are green when ran locally
- [x] I updated documentation/examples when needed
- [x] I considered backward compatibility and migration impact
